### PR TITLE
feature: bottom sheet 추가

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,7 @@
   "extends": ["eslint:recommended", "next", "prettier"],
   "rules": {
     "prefer-const": "warn",
+    "no-undef": "off",
     "import/order": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
     "emotion-reset": "^3.0.1",
+    "lodash": "^4.17.21",
     "next": "12.1.2",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
@@ -47,6 +48,7 @@
     "@storybook/react": "^6.4.19",
     "@storybook/testing-library": "^0.0.9",
     "@svgr/webpack": "^5.5.0",
+    "@types/lodash": "^4.14.182",
     "@types/node": "^17.0.25",
     "@types/react": "^18.0.1",
     "@types/react-dom": "^18.0.1",

--- a/src/components/BottomSheet/BottomSheet.stories.tsx
+++ b/src/components/BottomSheet/BottomSheet.stories.tsx
@@ -1,0 +1,41 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import styled from '@emotion/styled';
+
+import BottomSheet from './BottomSheet';
+
+export default {
+  title: 'Components/BottomSheet',
+  component: BottomSheet,
+  argTypes: {
+    open: { control: 'boolean', defaultValue: false },
+    isFull: { control: 'boolean', defaultValue: false },
+    backgroundColor: { control: 'color' },
+    children: { control: 'readonly' },
+    onClick: { control: 'readonly' },
+  },
+} as ComponentMeta<typeof BottomSheet>;
+
+const StyledWrapper = styled.div`
+  height: 6rem;
+  padding: 1.6rem;
+
+  h1 {
+    font-size: 1.3rem;
+    font-weight: 700;
+    margin-bottom: 0.8rem;
+  }
+`;
+
+const Template: ComponentStory<typeof BottomSheet> = (args) => {
+  return (
+    <BottomSheet {...args}>
+      <StyledWrapper>
+        <h1>바텀시트 📝</h1>
+        <p>스토리북에서는 onClose prop을 넘겨주지 않아 dim 영역을 클릭해도 닫히지 않습니다 🥲</p>
+      </StyledWrapper>
+    </BottomSheet>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/components/BottomSheet/BottomSheet.stories.tsx
+++ b/src/components/BottomSheet/BottomSheet.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: 'Components/BottomSheet',
   component: BottomSheet,
   argTypes: {
-    open: { control: 'boolean', defaultValue: false },
+    open: { control: 'boolean', defaultValue: true },
     isFull: { control: 'boolean', defaultValue: false },
     backgroundColor: { control: 'color' },
     children: { control: 'readonly' },

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -1,0 +1,88 @@
+import { ReactNode, RefObject } from 'react';
+import styled from '@emotion/styled';
+import { css, keyframes } from '@emotion/react';
+
+import ModalLayout from '../ModalLayout';
+
+import { useElementSize } from '@/hooks/useElementSize';
+
+const showUp = (height?: number) => keyframes`
+  from {
+    bottom: -${height ?? '100'}px;
+  }
+  to {
+    bottom: 0;
+  }
+`;
+
+const hideDown = (height?: number) => keyframes`
+  from {
+      bottom: 0;
+  }
+  to {
+      bottom: -${height ?? '100'}px;
+  }
+`;
+
+interface StyledWrapperProps extends Pick<BottomSheetProps, 'open' | 'isFull' | 'backgroundColor'> {
+  height?: number;
+}
+
+const StyledWrapper = styled.div<StyledWrapperProps>`
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  ${(p) => (p.isFull ? 'height: 90vh;' : '')};
+  max-height: 90vh;
+  border-radius: 2rem 2rem 0 0;
+
+  background-color: ${(p) => p.backgroundColor};
+
+  overflow: hidden;
+
+  ${(p) =>
+    css`
+      animation: ${p.open ? showUp(p.height) : hideDown(p.height)} 0.1s forwards;
+    `}
+`;
+
+const DEFAULT_BACKGROUND_COLOR = '#fff';
+
+interface BottomSheetProps {
+  open: boolean;
+  children: ReactNode;
+  onClose?: VoidFunction;
+  /** 화면의 90%를 차지하는 바텀시트임의 여부 (default: false) */
+  isFull?: boolean;
+  /** 백그라운드 색상 (default: #fff) */
+  backgroundColor?: string;
+}
+
+const BottomSheet: React.FC<BottomSheetProps> = ({
+  open,
+  children,
+  onClose,
+  isFull = false,
+  backgroundColor = DEFAULT_BACKGROUND_COLOR,
+}) => {
+  const { ref, size } = useElementSize();
+
+  return (
+    <ModalLayout open={open} onClose={onClose}>
+      <StyledWrapper
+        ref={ref as RefObject<HTMLDivElement>}
+        open={open}
+        height={size?.height}
+        isFull={isFull}
+        backgroundColor={backgroundColor}
+        aria-modal="true"
+      >
+        {children}
+      </StyledWrapper>
+    </ModalLayout>
+  );
+};
+
+export default BottomSheet;

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -8,7 +8,7 @@ import { useElementSize } from '@/hooks/useElementSize';
 
 const showUp = (height?: number) => keyframes`
   from {
-    bottom: -${height ?? '100'}px;
+    bottom: ${height ? `-${height}px` : `-100vh`};
   }
   to {
     bottom: 0;
@@ -17,10 +17,10 @@ const showUp = (height?: number) => keyframes`
 
 const hideDown = (height?: number) => keyframes`
   from {
-      bottom: 0;
+    bottom: 0;
   }
   to {
-      bottom: -${height ?? '100'}px;
+    bottom: ${height ? `-${height}px` : `-100vh`};
   }
 `;
 

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -6,21 +6,21 @@ import ModalLayout from '../ModalLayout';
 
 import { useElementSize } from '@/hooks/useElementSize';
 
-const showUp = (height?: number) => keyframes`
+const showUp = keyframes`
   from {
-    bottom: ${height ? `-${height}px` : `-100vh`};
+    transform: translateY(100%);
   }
   to {
-    bottom: 0;
+    transform: translateY(0);
   }
 `;
 
-const hideDown = (height?: number) => keyframes`
+const hideDown = keyframes`
   from {
-    bottom: 0;
+    transform: translateY(0);
   }
   to {
-    bottom: ${height ? `-${height}px` : `-100vh`};
+    transform: translateY(100%);
   }
 `;
 
@@ -42,9 +42,11 @@ const StyledWrapper = styled.div<StyledWrapperProps>`
 
   overflow: hidden;
 
+  transform: ${(p) => (p.open ? `translateY(0)` : `translateY(100%)`)};
+
   ${(p) =>
     css`
-      animation: ${p.open ? showUp(p.height) : hideDown(p.height)} 0.1s forwards;
+      animation: ${p.open ? showUp : hideDown} 0.1s forwards;
     `};
 `;
 

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -67,7 +67,9 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
   isFull = false,
   backgroundColor = DEFAULT_BACKGROUND_COLOR,
 }) => {
-  const { ref, size } = useElementSize<HTMLDivElement>();
+  const { ref, size } = useElementSize<HTMLDivElement>({
+    debounce: true,
+  });
 
   return (
     <ModalLayout open={open} onClose={onClose}>

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -46,7 +46,7 @@ const StyledWrapper = styled.div<StyledWrapperProps>`
 
   ${(p) =>
     css`
-      animation: ${p.open ? showUp : hideDown} 0.1s forwards;
+      animation: ${p.open ? showUp : hideDown} 0.3s forwards;
     `};
 `;
 

--- a/src/components/BottomSheet/BottomSheet.tsx
+++ b/src/components/BottomSheet/BottomSheet.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, RefObject } from 'react';
+import { ReactNode } from 'react';
 import styled from '@emotion/styled';
 import { css, keyframes } from '@emotion/react';
 
@@ -45,7 +45,7 @@ const StyledWrapper = styled.div<StyledWrapperProps>`
   ${(p) =>
     css`
       animation: ${p.open ? showUp(p.height) : hideDown(p.height)} 0.1s forwards;
-    `}
+    `};
 `;
 
 const DEFAULT_BACKGROUND_COLOR = '#fff';
@@ -67,12 +67,12 @@ const BottomSheet: React.FC<BottomSheetProps> = ({
   isFull = false,
   backgroundColor = DEFAULT_BACKGROUND_COLOR,
 }) => {
-  const { ref, size } = useElementSize();
+  const { ref, size } = useElementSize<HTMLDivElement>();
 
   return (
     <ModalLayout open={open} onClose={onClose}>
       <StyledWrapper
-        ref={ref as RefObject<HTMLDivElement>}
+        ref={ref}
         open={open}
         height={size?.height}
         isFull={isFull}

--- a/src/components/BottomSheet/index.ts
+++ b/src/components/BottomSheet/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BottomSheet';

--- a/src/components/ModalLayout/ModalLayout.stories.tsx
+++ b/src/components/ModalLayout/ModalLayout.stories.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import styled from '@emotion/styled';
+
+import ModalLayout from './ModalLayout';
+
+export default {
+  title: 'Components/ModalLayout',
+  component: ModalLayout,
+} as ComponentMeta<typeof ModalLayout>;
+
+const white = '#fff';
+
+const StyledWrapper = styled.div<{ open: boolean }>`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+
+  display: flex;
+  flex-direction: column;
+  width: 60%;
+
+  padding: 1.6rem;
+  border-radius: 1.6rem;
+
+  background-color: ${white};
+
+  ${(p) => !p.open && `display:none;`}
+
+  > p {
+    height: 3rem;
+  }
+`;
+
+const Template: ComponentStory<typeof ModalLayout> = (args) => {
+  const [open, setOpen] = useState(false);
+
+  const openModal = () => setOpen(true);
+  const closeModal = () => setOpen(false);
+
+  return (
+    <>
+      <button onClick={openModal}>Open Modal</button>
+      <ModalLayout open={open} onClose={closeModal}>
+        <StyledWrapper open={open}>
+          <p>모달</p>
+          <button onClick={closeModal}>취소</button>
+          <button onClick={closeModal}>확인</button>
+        </StyledWrapper>
+      </ModalLayout>
+    </>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/components/ModalLayout/ModalLayout.tsx
+++ b/src/components/ModalLayout/ModalLayout.tsx
@@ -1,6 +1,8 @@
-import React, { ReactNode, useEffect, useState } from 'react';
+import React, { ReactNode, useRef } from 'react';
 import styled from '@emotion/styled';
 import { css, keyframes } from '@emotion/react';
+
+import { useModalLayoutVisible } from './hooks/useModalLayoutVisible';
 
 const StyledContainer = styled.div<{ open: boolean }>`
   position: fixed;
@@ -56,25 +58,8 @@ interface ModalLayoutProps {
 }
 
 const ModalLayout: React.FC<ModalLayoutProps> = ({ open, children, onClose }) => {
-  const [isVisible, setIsVisible] = useState<boolean>(open);
-
-  /** 애니메이션이 끝난 후에 모달이 안보이도록 하기 위함 */
-  useEffect(() => {
-    if (open && !isVisible) {
-      setIsVisible(true);
-      return;
-    }
-
-    let timerId: NodeJS.Timeout;
-
-    if (!open && isVisible) {
-      timerId = setTimeout(() => {
-        setIsVisible(false);
-      }, 300);
-    }
-
-    () => clearTimeout(timerId);
-  }, [open, isVisible]);
+  const dimRef = useRef<HTMLDivElement>(null);
+  const isVisible = useModalLayoutVisible(open, dimRef);
 
   if (!isVisible) {
     return null;
@@ -82,7 +67,7 @@ const ModalLayout: React.FC<ModalLayoutProps> = ({ open, children, onClose }) =>
 
   return (
     <StyledContainer open={open}>
-      <StyledDim open={open} onClick={onClose} />
+      <StyledDim ref={dimRef} open={open} onClick={onClose} />
       {children}
     </StyledContainer>
   );

--- a/src/components/ModalLayout/ModalLayout.tsx
+++ b/src/components/ModalLayout/ModalLayout.tsx
@@ -1,0 +1,91 @@
+import React, { ReactNode, useEffect, useState } from 'react';
+import styled from '@emotion/styled';
+import { css, keyframes } from '@emotion/react';
+
+const StyledContainer = styled.div<{ open: boolean }>`
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100vw;
+  max-width: 768px;
+  height: 100vh;
+
+  overflow: hidden;
+
+  ${(p) => !p.open && 'pointer-events: none;'}
+`;
+
+export const fadeIn = keyframes`
+  from {
+    opacity:0;
+  }
+
+  to {
+    opacity:1;
+  }
+`;
+
+export const fadeOut = keyframes`
+  from {
+    opacity:1;
+  }
+
+  to {
+    opacity:0;
+  }
+`;
+
+const StyledDim = styled.div<{ open: boolean }>`
+  width: 100%;
+  height: 100%;
+
+  background-color: rgba(51, 51, 51, 0.8);
+
+  ${(p) =>
+    css`
+      animation: ${p.open ? fadeIn : fadeOut} 0.3s forwards;
+    `}
+`;
+
+interface ModalLayoutProps {
+  open: boolean;
+  children?: ReactNode;
+  onClose?: VoidFunction;
+}
+
+const ModalLayout: React.FC<ModalLayoutProps> = ({ open, children, onClose }) => {
+  const [isVisible, setIsVisible] = useState<boolean>(open);
+
+  /** 애니메이션이 끝난 후에 모달이 안보이도록 하기 위함 */
+  useEffect(() => {
+    if (open && !isVisible) {
+      setIsVisible(true);
+      return;
+    }
+
+    let timerId: NodeJS.Timeout;
+
+    if (!open && isVisible) {
+      timerId = setTimeout(() => {
+        setIsVisible(false);
+      }, 300);
+    }
+
+    () => clearTimeout(timerId);
+  }, [open, isVisible]);
+
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <StyledContainer open={open}>
+      <StyledDim open={open} onClick={onClose} />
+      {children}
+    </StyledContainer>
+  );
+};
+
+export default ModalLayout;

--- a/src/components/ModalLayout/hooks/useModalLayoutVisible.ts
+++ b/src/components/ModalLayout/hooks/useModalLayoutVisible.ts
@@ -1,0 +1,32 @@
+import { RefObject, useCallback, useEffect, useState } from 'react';
+
+export const useModalLayoutVisible = <T extends HTMLElement>(
+  open: boolean,
+  dimRef: RefObject<T>,
+) => {
+  const [isVisible, setIsVisible] = useState<boolean>(open);
+
+  useEffect(() => {
+    open && !isVisible && setIsVisible(true);
+  }, [open, isVisible]);
+
+  const handleAnimationend = useCallback(() => {
+    !open && isVisible && setIsVisible(false);
+  }, [open, isVisible]);
+
+  /** 애니메이션이 끝난 후에 모달이 안보이도록 함 */
+  useEffect(() => {
+    let divRefValue: T | null = null;
+
+    if (dimRef.current) {
+      divRefValue = dimRef.current;
+      divRefValue.addEventListener('animationend', handleAnimationend);
+    }
+
+    return () => {
+      divRefValue && divRefValue.removeEventListener('animationend', handleAnimationend);
+    };
+  }, [dimRef, handleAnimationend]);
+
+  return isVisible;
+};

--- a/src/components/ModalLayout/index.ts
+++ b/src/components/ModalLayout/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ModalLayout';

--- a/src/hooks/useElementSize.ts
+++ b/src/hooks/useElementSize.ts
@@ -10,11 +10,20 @@ export const useElementSize = <T extends HTMLElement>(): {
   useEffect(() => {
     if (!ref.current) return;
 
-    setSize({
-      width: ref.current.clientWidth,
-      height: ref.current.clientHeight,
+    const resizeObserver = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry.contentRect) {
+        setSize({
+          width: entry.contentRect.width,
+          height: entry.contentRect.height,
+        });
+      }
     });
-  }, [ref.current?.clientWidth, ref.current?.clientHeight]);
+
+    resizeObserver.observe(ref.current);
+
+    return () => resizeObserver.disconnect();
+  }, [ref]);
 
   return { ref, size };
 };

--- a/src/hooks/useElementSize.ts
+++ b/src/hooks/useElementSize.ts
@@ -1,0 +1,20 @@
+import { useRef, useState, useEffect, RefObject } from 'react';
+
+export const useElementSize = (): {
+  ref: RefObject<HTMLElement>;
+  size: { width: number; height: number } | null;
+} => {
+  const ref = useRef<HTMLElement>(null);
+  const [size, setSize] = useState<{ width: number; height: number } | null>(null);
+
+  useEffect(() => {
+    if (!ref.current) return;
+
+    setSize({
+      width: ref.current.clientWidth,
+      height: ref.current.clientHeight,
+    });
+  }, [ref.current?.clientWidth, ref.current?.clientHeight]);
+
+  return { ref, size };
+};

--- a/src/hooks/useElementSize.ts
+++ b/src/hooks/useElementSize.ts
@@ -7,9 +7,7 @@ interface useElementSizeOptions {
   debounce?: boolean;
 }
 
-export const useElementSize = <T extends HTMLElement>(
-  option?: useElementSizeOptions,
-): {
+export const useElementSize = <T extends HTMLElement>({ debounce }: useElementSizeOptions = {}): {
   ref: RefObject<T>;
   size: { width: number; height: number } | null;
 } => {
@@ -30,14 +28,12 @@ export const useElementSize = <T extends HTMLElement>(
     if (!ref.current) return;
 
     const debouncedResizeHandler = _debounce(resizeHandler, DEBOUNCE_WAIT_TIME);
-    const resizeObserver = new ResizeObserver(
-      option?.debounce ? debouncedResizeHandler : resizeHandler,
-    );
+    const resizeObserver = new ResizeObserver(debounce ? debouncedResizeHandler : resizeHandler);
 
     resizeObserver.observe(ref.current);
 
     return () => resizeObserver.disconnect();
-  }, [ref, resizeHandler, option]);
+  }, [ref, resizeHandler, debounce]);
 
   return { ref, size };
 };

--- a/src/hooks/useElementSize.ts
+++ b/src/hooks/useElementSize.ts
@@ -16,7 +16,7 @@ export const useElementSize = <T extends HTMLElement>(
   const ref = useRef<T>(null);
   const [size, setSize] = useState<{ width: number; height: number } | null>(null);
 
-  const callback: ResizeObserverCallback = useCallback((entries) => {
+  const resizeHandler: ResizeObserverCallback = useCallback((entries) => {
     const entry = entries[0];
     if (entry.contentRect) {
       setSize({
@@ -29,13 +29,15 @@ export const useElementSize = <T extends HTMLElement>(
   useEffect(() => {
     if (!ref.current) return;
 
-    const debouncedCallback = _debounce(callback, DEBOUNCE_WAIT_TIME);
-    const resizeObserver = new ResizeObserver(option?.debounce ? debouncedCallback : callback);
+    const debouncedResizeHandler = _debounce(resizeHandler, DEBOUNCE_WAIT_TIME);
+    const resizeObserver = new ResizeObserver(
+      option?.debounce ? debouncedResizeHandler : resizeHandler,
+    );
 
     resizeObserver.observe(ref.current);
 
     return () => resizeObserver.disconnect();
-  }, [ref]);
+  }, [ref, resizeHandler, option]);
 
   return { ref, size };
 };

--- a/src/hooks/useElementSize.ts
+++ b/src/hooks/useElementSize.ts
@@ -1,10 +1,10 @@
 import { useRef, useState, useEffect, RefObject } from 'react';
 
-export const useElementSize = (): {
-  ref: RefObject<HTMLElement>;
+export const useElementSize = <T extends HTMLElement>(): {
+  ref: RefObject<T>;
   size: { width: number; height: number } | null;
 } => {
-  const ref = useRef<HTMLElement>(null);
+  const ref = useRef<T>(null);
   const [size, setSize] = useState<{ width: number; height: number } | null>(null);
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2802,6 +2802,11 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/lodash@^4.14.182":
+  version "4.14.182"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
+  integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
+
 "@types/mdast@^3.0.0":
   version "3.0.10"
   resolved "https://registry.yarnpkg.com/@types/mdast/-/mdast-3.0.10.tgz#4724244a82a4598884cbbe9bcfd73dff927ee8af"


### PR DESCRIPTION
## 📍 주요 변경사항

[스토리북](https://62472322b43dfc003a759108-zzeeslvaey.chromatic.com/?path=/story/components-bottomsheet--default&args=open:true;isFull:true)

<img width="340" alt="image" src="https://user-images.githubusercontent.com/39763891/165333127-22012cdb-7f84-4e6d-8fe9-f0dcffa198c3.png">

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->


## 💡 중점적으로 봐주었으면 하는 부분

- border radius가 16, 20 인곳이 있더라구요 이 부분은 디자이너분과 논의 후 borderRadiusSize 같은 prop을 추가하거나 하나로 통일하도록 변경될 것 같아요
- isFull 인 경우 화면의 90%를 차지하도록 구현했는데 이부분도 논의가 필요한 부분인 것 같습니다!