### PR TITLE
feat: :sparkles: BeerStyleFilterItem 추가

### DIFF
--- a/src/assets/check.svg
+++ b/src/assets/check.svg
@@ -1,0 +1,3 @@
+<svg  viewBox="0 0 30 30" fill="current" xmlns="http://www.w3.org/2000/svg">
+<path d="M11.59 18.58L7.42 14.41L6 15.82L11.59 21.41L23.59 9.41L22.18 8L11.59 18.58Z" />
+</svg>

--- a/src/assets/icon.ts
+++ b/src/assets/icon.ts
@@ -1,3 +1,4 @@
+export { ReactComponent as CheckIcon } from './check.svg';
 export { ReactComponent as HistoryIcon } from './history.svg';
 export { ReactComponent as SearchIcon } from './search.svg';
 export { ReactComponent as FlightTakeOffIcon } from './flight_takeoff.svg';

--- a/src/components/filter/BeerStyleFilterItem/BeerStyleFilterItem.stories.tsx
+++ b/src/components/filter/BeerStyleFilterItem/BeerStyleFilterItem.stories.tsx
@@ -27,5 +27,4 @@ Default.args = {
     '투명한 황금빛으로 단 맛과 쓴 맛이 어우러진 깔끔한 맛',
   imageUrl: '',
   isSelected: true,
-  hasDivider: true,
 };

--- a/src/components/filter/BeerStyleFilterItem/BeerStyleFilterItem.stories.tsx
+++ b/src/components/filter/BeerStyleFilterItem/BeerStyleFilterItem.stories.tsx
@@ -1,0 +1,31 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import BeerStyleFilterItem from './BeerStyleFilterItem';
+
+export default {
+  title: 'Components/BeerStyleFilterItem',
+  component: BeerStyleFilterItem,
+  argTypes: {
+    title: { control: 'text' },
+    description: { control: 'text' },
+    imageUrl: { control: 'text' },
+    isSelected: { control: 'boolean' },
+    hasDivider: { control: 'boolean' },
+  },
+} as ComponentMeta<typeof BeerStyleFilterItem>;
+
+const Template: ComponentStory<typeof BeerStyleFilterItem> = (args) => (
+  <BeerStyleFilterItem {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  title: '필스너 필스너 필스너 필스너 필스너 필스너 필스너 필스너 필스너 필스너 ',
+  description:
+    '투명한 황금빛으로 단 맛과 쓴 맛이 어우러진 깔끔한 맛' +
+    '투명한 황금빛으로 단 맛과 쓴 맛이 어우러진 깔끔한 맛' +
+    '투명한 황금빛으로 단 맛과 쓴 맛이 어우러진 깔끔한 맛',
+  imageUrl: '',
+  isSelected: true,
+  hasDivider: true,
+};

--- a/src/components/filter/BeerStyleFilterItem/BeerStyleFilterItem.tsx
+++ b/src/components/filter/BeerStyleFilterItem/BeerStyleFilterItem.tsx
@@ -8,16 +8,17 @@ interface BeerStyleFilterItemProps {
   imageUrl: string;
   /** 선택 여부 (default:false) */
   isSelected?: boolean;
-  /** 하단 디바이더 유무 (default:true) */
-  hasDivider?: boolean;
 }
 
-const StyledWrapper = styled.li<Pick<BeerStyleFilterItemProps, 'hasDivider'>>`
+const StyledWrapper = styled.li`
   display: flex;
   flex-direction: row;
   align-items: center;
   padding: 1.4rem 2rem;
-  ${(p) => (p.hasDivider ? `border-bottom: 0.1rem solid ${p.theme.color.whiteOpacity35};` : '')};
+
+  & + li {
+    ${(p) => `border-top: 0.1rem solid ${p.theme.color.whiteOpacity35};`};
+  }
 
   > *:not(:last-child) {
     margin-right: 2rem;
@@ -78,10 +79,9 @@ const BeerStyleFilterItem = ({
   description,
   imageUrl,
   isSelected,
-  hasDivider = true,
 }: BeerStyleFilterItemProps) => {
   return (
-    <StyledWrapper hasDivider={hasDivider}>
+    <StyledWrapper>
       <img src={imageUrl} alt="" />
       <StyledInfo>
         <b>{title}</b>

--- a/src/components/filter/BeerStyleFilterItem/BeerStyleFilterItem.tsx
+++ b/src/components/filter/BeerStyleFilterItem/BeerStyleFilterItem.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import { CheckIcon } from '@/assets/icon';
+import { ellipsis } from '@/styles/common';
 
 const IMAGE_WIDTH = '70px';
 const CHECK_ICON_WIDTH = '30px';
@@ -58,9 +59,7 @@ const StyledInfo = styled.div`
     font-size: 16px;
     line-height: 19px;
 
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
+    ${ellipsis(1)};
   }
 
   > p {
@@ -68,12 +67,7 @@ const StyledInfo = styled.div`
     font-weight: 500;
     line-height: 18px;
 
-    text-overflow: ellipsis;
-    overflow: hidden;
-    word-break: break-word;
-    display: -webkit-box;
-    -webkit-line-clamp: 2; // 원하는 라인수
-    -webkit-box-orient: vertical;
+    ${ellipsis(2)};
   }
 `;
 

--- a/src/components/filter/BeerStyleFilterItem/BeerStyleFilterItem.tsx
+++ b/src/components/filter/BeerStyleFilterItem/BeerStyleFilterItem.tsx
@@ -1,0 +1,95 @@
+import styled from '@emotion/styled';
+
+import { CheckIcon } from '@/assets/icon';
+
+interface BeerStyleFilterItemProps {
+  title: string;
+  description: string;
+  imageUrl: string;
+  /** 선택 여부 (default:false) */
+  isSelected?: boolean;
+  /** 하단 디바이더 유무 (default:true) */
+  hasDivider?: boolean;
+}
+
+const StyledWrapper = styled.li<Pick<BeerStyleFilterItemProps, 'hasDivider'>>`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 1.4rem 2rem;
+  ${(p) => (p.hasDivider ? `border-bottom: 0.1rem solid ${p.theme.color.whiteOpacity35};` : '')};
+
+  > *:not(:last-child) {
+    margin-right: 2rem;
+  }
+
+  img {
+    flex-shrink: 0;
+    width: 7rem;
+    height: 7rem;
+  }
+
+  .check-icon {
+    flex-shrink: 0;
+    width: 3rem;
+    height: 3rem;
+    margin-left: auto;
+    fill: ${(p) => p.theme.semanticColor.secondary};
+  }
+`;
+
+const StyledInfo = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  max-width: calc(100% - 14rem);
+  height: 100%;
+
+  color: ${(p) => p.theme.color.white};
+
+  > b {
+    margin-bottom: 1rem;
+
+    font-weight: 700;
+    font-size: 1.6rem;
+    line-height: 1.9rem;
+
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  > p {
+    font-size: 1.3rem;
+    font-weight: 500;
+    line-height: 1.8rem;
+
+    text-overflow: ellipsis;
+    overflow: hidden;
+    word-break: break-word;
+    display: -webkit-box;
+    -webkit-line-clamp: 2; // 원하는 라인수
+    -webkit-box-orient: vertical;
+  }
+`;
+
+const BeerStyleFilterItem = ({
+  title,
+  description,
+  imageUrl,
+  isSelected,
+  hasDivider = true,
+}: BeerStyleFilterItemProps) => {
+  return (
+    <StyledWrapper hasDivider={hasDivider}>
+      <img src={imageUrl} alt="" />
+      <StyledInfo>
+        <b>{title}</b>
+        <p className="description">{description} </p>
+      </StyledInfo>
+      {isSelected && <CheckIcon className="check-icon" />}
+    </StyledWrapper>
+  );
+};
+
+export default BeerStyleFilterItem;

--- a/src/components/filter/BeerStyleFilterItem/BeerStyleFilterItem.tsx
+++ b/src/components/filter/BeerStyleFilterItem/BeerStyleFilterItem.tsx
@@ -2,8 +2,8 @@ import styled from '@emotion/styled';
 
 import { CheckIcon } from '@/assets/icon';
 
-const IMAGE_WIDTH = '7rem';
-const CHECK_ICON_WIDTH = '3rem';
+const IMAGE_WIDTH = '70px';
+const CHECK_ICON_WIDTH = '30px';
 
 interface BeerStyleFilterItemProps {
   title: string;
@@ -17,14 +17,14 @@ const StyledWrapper = styled.li`
   display: flex;
   flex-direction: row;
   align-items: center;
-  padding: 1.4rem 2rem;
+  padding: 14px 20px;
 
   & + li {
-    ${(p) => `border-top: 0.1rem solid ${p.theme.color.whiteOpacity35};`};
+    ${(p) => `border-top: 1px solid ${p.theme.color.whiteOpacity35};`};
   }
 
   > *:not(:last-child) {
-    margin-right: 2rem;
+    margin-right: 20px;
   }
 
   img {
@@ -46,18 +46,17 @@ const StyledInfo = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  /** 4rem -> 요소 사이 간격 합 */
-  max-width: calc(100% - ${IMAGE_WIDTH} - ${CHECK_ICON_WIDTH} - 4rem);
+  max-width: calc(100% - ${IMAGE_WIDTH} - ${CHECK_ICON_WIDTH} - 40px);
   height: 100%;
 
   color: ${(p) => p.theme.color.white};
 
   > b {
-    margin-bottom: 1rem;
+    margin-bottom: 10px;
 
     font-weight: 700;
-    font-size: 1.6rem;
-    line-height: 1.9rem;
+    font-size: 16px;
+    line-height: 19px;
 
     text-overflow: ellipsis;
     overflow: hidden;
@@ -65,9 +64,9 @@ const StyledInfo = styled.div`
   }
 
   > p {
-    font-size: 1.3rem;
+    font-size: 13px;
     font-weight: 500;
-    line-height: 1.8rem;
+    line-height: 18px;
 
     text-overflow: ellipsis;
     overflow: hidden;

--- a/src/components/filter/BeerStyleFilterItem/BeerStyleFilterItem.tsx
+++ b/src/components/filter/BeerStyleFilterItem/BeerStyleFilterItem.tsx
@@ -2,6 +2,9 @@ import styled from '@emotion/styled';
 
 import { CheckIcon } from '@/assets/icon';
 
+const IMAGE_WIDTH = '7rem';
+const CHECK_ICON_WIDTH = '3rem';
+
 interface BeerStyleFilterItemProps {
   title: string;
   description: string;
@@ -26,14 +29,14 @@ const StyledWrapper = styled.li`
 
   img {
     flex-shrink: 0;
-    width: 7rem;
-    height: 7rem;
+    width: ${IMAGE_WIDTH};
+    height: ${IMAGE_WIDTH};
   }
 
   .check-icon {
     flex-shrink: 0;
-    width: 3rem;
-    height: 3rem;
+    width: ${CHECK_ICON_WIDTH};
+    height: ${CHECK_ICON_WIDTH};
     margin-left: auto;
     fill: ${(p) => p.theme.semanticColor.secondary};
   }
@@ -43,7 +46,8 @@ const StyledInfo = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;
-  max-width: calc(100% - 14rem);
+  /** 4rem -> 요소 사이 간격 합 */
+  max-width: calc(100% - ${IMAGE_WIDTH} - ${CHECK_ICON_WIDTH} - 4rem);
   height: 100%;
 
   color: ${(p) => p.theme.color.white};

--- a/src/components/filter/BeerStyleFilterItem/index.ts
+++ b/src/components/filter/BeerStyleFilterItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BeerStyleFilterItem';

--- a/src/styles/common.ts
+++ b/src/styles/common.ts
@@ -1,0 +1,15 @@
+import { css } from '@emotion/react';
+
+/** @note 요소의 width가 존재해야 올바르게 동작합니다. */
+export const ellipsis = (lineCount: number = 1) => css`
+  text-overflow: ellipsis;
+  overflow: hidden;
+  ${lineCount === 1
+    ? 'white-space: nowrap;'
+    : `
+      word-break: break-word;
+      display: -webkit-box;
+      -webkit-line-clamp: ${lineCount}; 
+      -webkit-box-orient: vertical;
+      `};
+`;


### PR DESCRIPTION
## 📍 주요 변경사항

[스토리북](https://62472322b43dfc003a759108-wsbvtyxnxz.chromatic.com/?path=/story/components-beerstylefilteritem--default)

<img width="550" alt="image" src="https://user-images.githubusercontent.com/39763891/166281560-cc2fd1ed-bca2-45ab-93fc-f4818b173460.png">

이미지는 아무 맥주나 넣어보았습니다

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->


## 💡 중점적으로 봐주었으면 하는 부분

* 맥주 종류가 beer style이라길래 네이밍을 맥주 종류 필터 이이템 -> BeerStyleFilterItem으로 정했습니다
* 10px -> 1rem으로 해서 rem으로 만들었는데 iphone5에서는 이렇게 나와서 🤔 
px로 사용하고 기기별로 미디어 쿼리 분기쳐서 해결해야하나 싶기도 해요ㅠ (화욜 회의때 정해보면 좋을 것같아요)

<img width="488" alt="image" src="https://user-images.githubusercontent.com/39763891/166288715-2763cdfa-4852-470a-b0a7-d6c6f3b97027.png">


* ellipsis 같은 경우 글로벌 모듈로 분리해도 좋을 것 같은데 theme?은 또아닌 것 같기도 해서 styles 폴더를 추가해야하나? 등 폴더 구조나 이름이 고민 되어요!