### PR TITLE
feature: Tab 컴포넌트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,9 @@
   "dependencies": {
     "@emotion/react": "^11.8.2",
     "@emotion/styled": "^11.8.1",
-    "classnames": "^2.3.1",
     "@hookform/devtools": "^4.1.0",
-    "clipboard-polyfill": "^4.0.0-rc1",
     "classnames": "^2.3.1",
+    "clipboard-polyfill": "^4.0.0-rc1",
     "emotion-reset": "^3.0.1",
     "lodash": "^4.17.21",
     "next": "12.1.2",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-hook-form": "^7.30.0",
+    "react-responsive-carousel": "^3.2.23",
     "recoil": "^0.7.2"
   },
   "devDependencies": {

--- a/src/components/Swiper/Swiper.stories.tsx
+++ b/src/components/Swiper/Swiper.stories.tsx
@@ -1,0 +1,30 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import styled from '@emotion/styled';
+
+import Swiper from './Swiper';
+
+export default {
+  title: 'Components/Swiper',
+  component: Swiper,
+} as ComponentMeta<typeof Swiper>;
+
+const TabPage = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  background-color: ${(p) => p.theme.color.whiteOpacity20};
+`;
+
+const Template: ComponentStory<typeof Swiper> = (args) => (
+  <Swiper {...args}>
+    {Array(6)
+      .fill(0)
+      .map((value, index) => (
+        <TabPage key={index}>page {index + 1}</TabPage>
+      ))}
+  </Swiper>
+);
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/src/components/Swiper/Swiper.tsx
+++ b/src/components/Swiper/Swiper.tsx
@@ -1,0 +1,18 @@
+import { Carousel, CarouselProps } from 'react-responsive-carousel';
+import 'react-responsive-carousel/lib/styles/carousel.min.css';
+
+const carouselInitialProps: Partial<CarouselProps> = {
+  showArrows: false,
+  showStatus: false,
+  showIndicators: false,
+  showThumbs: false,
+  emulateTouch: true,
+};
+
+interface SwiperProps extends Partial<CarouselProps> {}
+
+const Swiper = (props: SwiperProps) => {
+  return <Carousel {...carouselInitialProps} {...props} />;
+};
+
+export default Swiper;

--- a/src/components/Swiper/Swiper.tsx
+++ b/src/components/Swiper/Swiper.tsx
@@ -9,9 +9,7 @@ const carouselInitialProps: Partial<CarouselProps> = {
   emulateTouch: true,
 };
 
-interface SwiperProps extends Partial<CarouselProps> {}
-
-const Swiper = (props: SwiperProps) => {
+const Swiper = (props: Partial<CarouselProps>) => {
   return <Carousel {...carouselInitialProps} {...props} />;
 };
 

--- a/src/components/Swiper/index.ts
+++ b/src/components/Swiper/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Swiper';

--- a/src/components/Tab/Tab.stories.tsx
+++ b/src/components/Tab/Tab.stories.tsx
@@ -1,0 +1,39 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import styled from '@emotion/styled';
+
+import Tab from './Tab';
+
+export default {
+  title: 'Components/Tab',
+  component: Tab,
+  argTypes: {
+    isSwipable: { control: 'boolean', defaultValue: false },
+  },
+} as ComponentMeta<typeof Tab>;
+
+const TabPage = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100px;
+  background-color: ${(p) => p.theme.color.whiteOpacity20};
+`;
+
+const Template: ComponentStory<typeof Tab> = (args) => (
+  <>
+    <Tab {...args} onChange={(index) => console.log(index)}>
+      <div>
+        <TabPage>page1</TabPage>
+      </div>
+      <div>
+        <TabPage>page2</TabPage>
+      </div>
+    </Tab>
+  </>
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  tabItems: ['종류', '대륙'],
+  defaultActivatedIndex: 0,
+};

--- a/src/components/Tab/Tab.stories.tsx
+++ b/src/components/Tab/Tab.stories.tsx
@@ -7,7 +7,8 @@ export default {
   title: 'Components/Tab',
   component: Tab,
   argTypes: {
-    isSwipable: { control: 'boolean', defaultValue: false },
+    isSwipable: { control: 'boolean', defaultValue: true },
+    isGhost: { control: 'boolean', defaultValue: false },
   },
 } as ComponentMeta<typeof Tab>;
 
@@ -15,33 +16,59 @@ const TabPage = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
-  height: 100px;
+  height: 200px;
   background-color: ${(p) => p.theme.color.whiteOpacity20};
 `;
 
 const Template: ComponentStory<typeof Tab> = (args) => (
-  <>
-    <Tab {...args} onChange={(index) => console.log(index)}>
-      <div>
-        <TabPage>page1</TabPage>
-      </div>
-      <div>
-        <TabPage>page2</TabPage>
-      </div>
-    </Tab>
-  </>
+  <Tab {...args} onChange={(index) => console.log(index)}>
+    {Array(args.tabItems.length)
+      .fill(0)
+      .map((_, index) => (
+        <TabPage key={index}>page {index + 1}</TabPage>
+      ))}
+  </Tab>
 );
 
 export const Primary = Template.bind({});
 Primary.args = {
   type: 'primary',
   tabItems: ['종류', '대륙'],
-  defaultActivatedIndex: 0,
 };
 
 export const Secondary = Template.bind({});
 Secondary.args = {
   type: 'secondary',
   tabItems: ['안 마셔본 맥주', '반한 맥주'],
-  defaultActivatedIndex: 0,
+};
+
+const countries = ['전체', '아시아', '유럽', '북아메리카', '남아메리카', '호주'];
+
+export const Primary_Ghost_small = Template.bind({});
+Primary_Ghost_small.args = {
+  type: 'primary',
+  tabItems: countries,
+  isGhost: true,
+  size: 'small',
+};
+
+const Template2: ComponentStory<typeof Tab> = (args) => (
+  <Tab {...args} isSwipable={false}>
+    <TabPage>page1</TabPage>
+    <Tab tabItems={countries} size="small" type="primary" isGhost isSwipable>
+      {Array(countries.length)
+        .fill(0)
+        .map((_, index) => (
+          <div key={index}>
+            <TabPage>page {index + 1}</TabPage>
+          </div>
+        ))}
+    </Tab>
+  </Tab>
+);
+
+export const 필터_탭 = Template2.bind({});
+필터_탭.args = {
+  type: 'primary',
+  tabItems: ['종류', '대륙'],
 };

--- a/src/components/Tab/Tab.stories.tsx
+++ b/src/components/Tab/Tab.stories.tsx
@@ -32,8 +32,16 @@ const Template: ComponentStory<typeof Tab> = (args) => (
   </>
 );
 
-export const Default = Template.bind({});
-Default.args = {
+export const Primary = Template.bind({});
+Primary.args = {
+  type: 'primary',
   tabItems: ['종류', '대륙'],
+  defaultActivatedIndex: 0,
+};
+
+export const Secondary = Template.bind({});
+Secondary.args = {
+  type: 'secondary',
+  tabItems: ['안 마셔본 맥주', '반한 맥주'],
   defaultActivatedIndex: 0,
 };

--- a/src/components/Tab/Tab.stories.tsx
+++ b/src/components/Tab/Tab.stories.tsx
@@ -1,7 +1,9 @@
+import { useState } from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import styled from '@emotion/styled';
 
 import Tab from './Tab';
+import Swiper from '../Swiper';
 
 export default {
   title: 'Components/Tab',
@@ -12,7 +14,13 @@ export default {
   },
 } as ComponentMeta<typeof Tab>;
 
-const TabPage = styled.div`
+const StyledH1 = styled.h1`
+  margin: 12px 0 8px;
+  font-size: 16px;
+  font-weight: 600;
+`;
+
+const StyledTabPage = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -20,15 +28,36 @@ const TabPage = styled.div`
   background-color: ${(p) => p.theme.color.whiteOpacity20};
 `;
 
-const Template: ComponentStory<typeof Tab> = (args) => (
-  <Tab {...args} onChange={(index) => console.log(index)}>
-    {Array(args.tabItems.length)
-      .fill(0)
-      .map((_, index) => (
-        <TabPage key={index}>page {index + 1}</TabPage>
-      ))}
-  </Tab>
-);
+const Template: ComponentStory<typeof Tab> = (args) => {
+  const [activatedIndex, setActivatedIndex] = useState(0);
+
+  return (
+    <>
+      <div>
+        <StyledH1>children 타입: ReactChild[]</StyledH1>
+        <Tab {...args} outerActivatedIndex={activatedIndex} onChange={setActivatedIndex}>
+          {Array(args.tabItems.length)
+            .fill(0)
+            .map((_, index) => (
+              <StyledTabPage key={index}>page {index + 1}</StyledTabPage>
+            ))}
+        </Tab>
+      </div>
+      <div>
+        <StyledH1>children 타입: ReactChild (children에 스와이프 적용)</StyledH1>
+        <Tab {...args} outerActivatedIndex={activatedIndex} onChange={setActivatedIndex}>
+          <Swiper selectedItem={activatedIndex} onChange={setActivatedIndex}>
+            {Array(args.tabItems.length)
+              .fill(0)
+              .map((_, index) => (
+                <StyledTabPage key={index}>page {index + 1}</StyledTabPage>
+              ))}
+          </Swiper>
+        </Tab>
+      </div>
+    </>
+  );
+};
 
 export const Primary = Template.bind({});
 Primary.args = {
@@ -53,15 +82,13 @@ Primary_Ghost_small.args = {
 };
 
 const Template2: ComponentStory<typeof Tab> = (args) => (
-  <Tab {...args} isSwipable={false}>
-    <TabPage>page1</TabPage>
-    <Tab tabItems={countries} size="small" type="primary" isGhost isSwipable>
+  <Tab {...args}>
+    <StyledTabPage>page1</StyledTabPage>
+    <Tab tabItems={countries} size="small" type="primary" isGhost>
       {Array(countries.length)
         .fill(0)
         .map((_, index) => (
-          <div key={index}>
-            <TabPage>page {index + 1}</TabPage>
-          </div>
+          <StyledTabPage key={index}>page {index + 1}</StyledTabPage>
         ))}
     </Tab>
   </Tab>

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -3,13 +3,19 @@ import styled from '@emotion/styled';
 import { Carousel, CarouselProps } from 'react-responsive-carousel';
 import 'react-responsive-carousel/lib/styles/carousel.min.css';
 
+import { ColorTheme } from '@/themes/types';
+
 const carouselInitialProps: Partial<CarouselProps> = {
   showArrows: false,
   showStatus: false,
   showIndicators: false,
 };
 
+type TabType = 'primary' | 'secondary';
+
 interface TabProps {
+  /** 탭 타입 (default: 'primary') */
+  type: TabType;
   // eslint-disable-next-line no-unused-vars
   onChange: (activatedIndex: number) => void;
   tabItems: string[];
@@ -36,7 +42,37 @@ const StyledCarousel = styled(Carousel)`
   flex: 1;
 `;
 
-const StyledTabButton = styled.button<{ isSelected: boolean }>`
+const getTabButtonBackgroundColor = ({
+  type,
+  isSelected,
+  theme,
+}: {
+  type: TabType;
+  isSelected: boolean;
+  theme: ColorTheme;
+}) => {
+  if (type === 'primary') {
+    return isSelected ? theme.semanticColor.primary : theme.color.whiteOpacity20;
+  }
+  return isSelected ? theme.semanticColor.secondary : theme.color.whiteOpacity20;
+};
+
+const getTabButtonColor = ({
+  type,
+  isSelected,
+  theme,
+}: {
+  type: TabType;
+  isSelected: boolean;
+  theme: ColorTheme;
+}) => {
+  if (type === 'primary') {
+    return isSelected ? theme.color.whiteOpacity80 : theme.color.white;
+  }
+  return isSelected ? theme.color.black80 : theme.color.whiteOpacity80;
+};
+
+const StyledTabButton = styled.button<{ isSelected: boolean; tabType: TabType }>`
   display: flex;
   align-items: center;
   justify-content: center;
@@ -48,9 +84,8 @@ const StyledTabButton = styled.button<{ isSelected: boolean }>`
   font-size: 15px;
   line-height: 18px;
 
-  background-color: ${(p) =>
-    p.isSelected ? p.theme.semanticColor.secondary : p.theme.color.whiteOpacity20};
-  color: ${(p) => (p.isSelected ? p.theme.color.black80 : p.theme.color.whiteOpacity80)};
+  background-color: ${(p) => getTabButtonBackgroundColor({ ...p, type: p.tabType })};
+  color: ${(p) => getTabButtonColor({ ...p, type: p.tabType })};
 
   & + button {
     margin-left: 10px;
@@ -58,6 +93,7 @@ const StyledTabButton = styled.button<{ isSelected: boolean }>`
 `;
 
 const Tab = ({
+  type = 'primary',
   onChange,
   tabItems = [],
   children,
@@ -84,6 +120,7 @@ const Tab = ({
       <StyledHeader>
         {tabItems.map((tabItem, index) => (
           <StyledTabButton
+            tabType={type}
             key={tabItem}
             isSelected={activatedIndex === index}
             onClick={() => handleTabChange(index)}

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, ReactChild, useRef } from 'react';
+import { useState, useEffect, ReactChild, useRef, useCallback } from 'react';
 import styled from '@emotion/styled';
 
 import { ColorTheme } from '@/themes/types';
@@ -118,13 +118,13 @@ const Tab = ({
   const tabListRef = useRef<HTMLUListElement>(null);
   const tabItemRefs = useRef<(HTMLLIElement | null)[]>([]);
 
-  const activatedTabItem = tabItemRefs.current[activatedIndex];
-
   useEffect(() => {
     setActivatedIndex(outerActivatedIndex);
   }, [outerActivatedIndex]);
 
-  const scrollToActivatedTabItem = () => {
+  const scrollToActivatedTabItem = useCallback(() => {
+    const activatedTabItem = tabItemRefs.current[activatedIndex];
+
     if (!activatedTabItem || !tabListRef.current) return;
 
     const isFirstTab = activatedIndex === 0;
@@ -138,7 +138,7 @@ const Tab = ({
         : activatedTabItem.offsetLeft,
       behavior: 'smooth',
     });
-  };
+  }, [activatedIndex, tabItems]);
 
   useEffect(() => {
     onChange(activatedIndex);
@@ -150,6 +150,8 @@ const Tab = ({
       }
     });
 
+    const activatedTabItem = tabItemRefs.current[activatedIndex];
+
     activatedTabItem && intersectionObserver.observe(activatedTabItem);
 
     /** tabListRef 스크롤시에는 활성화된 탭버튼으로 자동 스크롤되지 않도록 막아야한다. */
@@ -158,7 +160,7 @@ const Tab = ({
     });
 
     return () => intersectionObserver.disconnect();
-  }, [activatedIndex, onChange, tabItemRefs]);
+  }, [activatedIndex, onChange, scrollToActivatedTabItem]);
 
   return (
     <StyledWrapper className={className}>

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -154,12 +154,17 @@ const Tab = ({
 
     activatedTabItem && intersectionObserver.observe(activatedTabItem);
 
-    /** tabListRef 스크롤시에는 활성화된 탭버튼으로 자동 스크롤되지 않도록 막아야한다. */
-    tabListRef.current?.addEventListener('scroll', () => {
+    const handleTabListScroll = () => {
       intersectionObserver.disconnect();
-    });
+    };
 
-    return () => intersectionObserver.disconnect();
+    /** tabListRef 스크롤시에는 활성화된 탭버튼으로 자동 스크롤되지 않도록 막아야한다. */
+    tabListRef.current?.addEventListener('scroll', handleTabListScroll);
+
+    return () => {
+      intersectionObserver.disconnect();
+      tabListRef.current?.removeEventListener('scroll', handleTabListScroll);
+    };
   }, [activatedIndex, onChange, scrollToActivatedTabItem]);
 
   return (

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -9,6 +9,7 @@ const carouselInitialProps: Partial<CarouselProps> = {
   showArrows: false,
   showStatus: false,
   showIndicators: false,
+  showThumbs: false,
 };
 
 type TabType = 'primary' | 'secondary';

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -1,0 +1,107 @@
+import { useState, useEffect, ReactChild } from 'react';
+import styled from '@emotion/styled';
+import { Carousel, CarouselProps } from 'react-responsive-carousel';
+import 'react-responsive-carousel/lib/styles/carousel.min.css';
+
+const carouselInitialProps: Partial<CarouselProps> = {
+  showArrows: false,
+  showStatus: false,
+  showIndicators: false,
+};
+
+interface TabProps {
+  // eslint-disable-next-line no-unused-vars
+  onChange: (activatedIndex: number) => void;
+  tabItems: string[];
+  children: ReactChild[] | undefined;
+  defaultActivatedIndex?: number;
+  /** 스와이프 가능 여부 (default:false) */
+  isSwipable?: boolean;
+  className?: string;
+}
+
+const StyledWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledHeader = styled.div`
+  display: flex;
+  flex-shrink: 0;
+  padding: 12px 20px;
+`;
+
+const StyledCarousel = styled(Carousel)`
+  width: 100%;
+  flex: 1;
+`;
+
+const StyledTabButton = styled.button<{ isSelected: boolean }>`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  height: 36px;
+  border-radius: 20px;
+
+  font-weight: 600;
+  font-size: 15px;
+  line-height: 18px;
+
+  background-color: ${(p) =>
+    p.isSelected ? p.theme.semanticColor.secondary : p.theme.color.whiteOpacity20};
+  color: ${(p) => (p.isSelected ? p.theme.color.black80 : p.theme.color.whiteOpacity80)};
+
+  & + button {
+    margin-left: 10px;
+  }
+`;
+
+const Tab = ({
+  onChange,
+  tabItems = [],
+  children,
+  defaultActivatedIndex = 0,
+  isSwipable = false,
+  className,
+}: TabProps) => {
+  const [activatedIndex, setActivatedIndex] = useState(defaultActivatedIndex);
+
+  useEffect(() => {
+    setActivatedIndex(defaultActivatedIndex);
+  }, [defaultActivatedIndex]);
+
+  useEffect(() => {
+    onChange(activatedIndex);
+  }, [activatedIndex, onChange]);
+
+  const handleTabChange = (index: number) => {
+    setActivatedIndex(index);
+  };
+
+  return (
+    <StyledWrapper className={className}>
+      <StyledHeader>
+        {tabItems.map((tabItem, index) => (
+          <StyledTabButton
+            key={tabItem}
+            isSelected={activatedIndex === index}
+            onClick={() => handleTabChange(index)}
+          >
+            {tabItem}
+          </StyledTabButton>
+        ))}
+      </StyledHeader>
+      <StyledCarousel
+        {...carouselInitialProps}
+        emulateTouch={isSwipable}
+        selectedItem={activatedIndex}
+        onChange={handleTabChange}
+      >
+        {children}
+      </StyledCarousel>
+    </StyledWrapper>
+  );
+};
+
+export default Tab;

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -165,19 +165,23 @@ const Tab = ({
   return (
     <StyledWrapper className={className}>
       <StyledTabList ref={tabListRef} size={size}>
-        {tabItems.map((tabItem, index) => (
-          <StyledTabItem
-            ref={(element) => (tabItemRefs.current[index] = element)}
-            key={tabItem}
-            isSelected={activatedIndex === index}
-            onClick={() => setActivatedIndex(index)}
-            tabType={type}
-            isGhost={isGhost}
-            size={size}
-          >
-            <button>{tabItem}</button>
-          </StyledTabItem>
-        ))}
+        {tabItems.map((tabItem, index) => {
+          const isSelected = activatedIndex === index;
+          return (
+            <StyledTabItem
+              ref={(element) => (tabItemRefs.current[index] = element)}
+              key={tabItem}
+              isSelected={isSelected}
+              aria-checked={isSelected}
+              onClick={() => setActivatedIndex(index)}
+              tabType={type}
+              isGhost={isGhost}
+              size={size}
+            >
+              <button>{tabItem}</button>
+            </StyledTabItem>
+          );
+        })}
       </StyledTabList>
       {/**
        * 배열인 경우 activatedIndex번째의 children을 렌더링하고,

--- a/src/components/Tab/Tab.tsx
+++ b/src/components/Tab/Tab.tsx
@@ -1,34 +1,23 @@
 import { useState, useEffect, ReactChild, useRef } from 'react';
 import styled from '@emotion/styled';
-import { Carousel, CarouselProps } from 'react-responsive-carousel';
-import 'react-responsive-carousel/lib/styles/carousel.min.css';
 
 import { ColorTheme } from '@/themes/types';
-
-const carouselInitialProps: Partial<CarouselProps> = {
-  showArrows: false,
-  showStatus: false,
-  showIndicators: false,
-  showThumbs: false,
-};
 
 type TabType = 'primary' | 'secondary';
 type TabSize = 'small' | 'large';
 
 interface TabProps {
   tabItems: string[];
-  children: ReactChild[] | undefined;
-  defaultActivatedIndex?: number;
+  children?: ReactChild | ReactChild[];
+  /** 컴포넌트 외부에서 activatedIndex를 제어할 수 있게 하기 위한 속성  */
+  outerActivatedIndex?: number;
   /** 탭 타입 (default: 'primary') */
   type?: TabType;
   /** 고스트 타입 여부 (default:false) */
   isGhost?: boolean;
   /** 탭 사이즈 (default:'small') */
   size?: TabSize;
-  /** 스와이프 가능 여부 (default:false) */
-  isSwipable?: boolean;
   className?: string;
-  // eslint-disable-next-line no-unused-vars
   onChange?: (activatedIndex: number) => void;
 }
 
@@ -37,7 +26,7 @@ const StyledWrapper = styled.div`
   flex-direction: column;
 `;
 
-const StyledHeader = styled.div<Pick<TabProps, 'size'>>`
+const StyledTabList = styled.ul<Pick<TabProps, 'size'>>`
   display: flex;
   flex-shrink: 0;
   width: 100%;
@@ -45,12 +34,7 @@ const StyledHeader = styled.div<Pick<TabProps, 'size'>>`
   overflow-x: scroll;
 `;
 
-const StyledCarousel = styled(Carousel)`
-  width: 100%;
-  flex: 1;
-`;
-
-const getTabButtonBackgroundColor = ({
+const getTabItemBackgroundColor = ({
   type,
   isSelected,
   theme,
@@ -67,7 +51,7 @@ const getTabButtonBackgroundColor = ({
   return isSelected ? theme.semanticColor.secondary : theme.color.whiteOpacity20;
 };
 
-const getTabButtonColor = ({
+const getTabItemColor = ({
   type,
   isSelected,
   theme,
@@ -84,30 +68,37 @@ const getTabButtonColor = ({
   return isSelected ? theme.color.black80 : theme.color.whiteOpacity80;
 };
 
-const StyledTabButton = styled.button<
+const StyledTabItem = styled.li<
   { isSelected: boolean; tabType: TabType } & Pick<TabProps, 'isGhost' | 'size'>
 >`
-  display: flex;
-  align-items: center;
-  justify-content: center;
   flex: 1;
   min-width: fit-content;
   height: ${(p) => (p.size === 'large' ? '36px' : '29px')};
   border-radius: ${(p) => (p.size === 'large' ? '20px' : '25px')};
-  padding: 0 24px;
-
-  font-weight: ${(p) => (p.size === 'large' ? '600' : '500')};
-  font-size: ${(p) => (p.size === 'large' ? '15px' : '14px')};
-  line-height: ${(p) => (p.size === 'large' ? '18px' : '17px')};
-
-  background-color: ${(p) => getTabButtonBackgroundColor({ ...p, type: p.tabType })};
-  color: ${(p) => getTabButtonColor({ ...p, type: p.tabType })};
   ${(p) =>
     `border: 1px solid ${
       p.isGhost && !p.isSelected ? p.theme.color.whiteOpacity65 : 'transparent'
     };`};
+  background-color: ${(p) => getTabItemBackgroundColor({ ...p, type: p.tabType })};
+  color: ${(p) => getTabItemColor({ ...p, type: p.tabType })};
 
-  & + button {
+  > button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+
+    padding: 0 24px;
+
+    font-weight: ${(p) => (p.size === 'large' ? '600' : '500')};
+    font-size: ${(p) => (p.size === 'large' ? '15px' : '14px')};
+    line-height: ${(p) => (p.size === 'large' ? '18px' : '17px')};
+
+    color: inherit;
+  }
+
+  & + li {
     margin-left: 10px;
   }
 `;
@@ -115,37 +106,36 @@ const StyledTabButton = styled.button<
 const Tab = ({
   tabItems = [],
   children,
-  defaultActivatedIndex = 0,
+  outerActivatedIndex = 0,
   type = 'primary',
   isGhost = false,
   size = 'small',
-  isSwipable = false,
   className,
   onChange = () => null,
 }: TabProps) => {
-  const [activatedIndex, setActivatedIndex] = useState(defaultActivatedIndex);
+  const [activatedIndex, setActivatedIndex] = useState(outerActivatedIndex);
 
-  const tabHeaderRef = useRef<HTMLDivElement>(null);
-  const tabButtonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const tabListRef = useRef<HTMLUListElement>(null);
+  const tabItemRefs = useRef<(HTMLLIElement | null)[]>([]);
 
-  const activatedTabButton = tabButtonRefs.current[activatedIndex];
+  const activatedTabItem = tabItemRefs.current[activatedIndex];
 
   useEffect(() => {
-    setActivatedIndex(defaultActivatedIndex);
-  }, [defaultActivatedIndex]);
+    setActivatedIndex(outerActivatedIndex);
+  }, [outerActivatedIndex]);
 
-  const scrollToActivatedTabButton = () => {
-    if (!activatedTabButton || !tabHeaderRef.current) return;
+  const scrollToActivatedTabItem = () => {
+    if (!activatedTabItem || !tabListRef.current) return;
 
     const isFirstTab = activatedIndex === 0;
     const isLastTab = activatedIndex === tabItems.length - 1;
 
-    tabHeaderRef.current.scrollTo({
+    tabListRef.current.scrollTo({
       left: isFirstTab
         ? 0
         : isLastTab
-        ? tabHeaderRef.current.scrollWidth
-        : activatedTabButton.offsetLeft,
+        ? tabListRef.current.scrollWidth
+        : activatedTabItem.offsetLeft,
       behavior: 'smooth',
     });
   };
@@ -156,26 +146,26 @@ const Tab = ({
     const intersectionObserver = new IntersectionObserver((entries) => {
       const entry = entries[0];
       if (entry.intersectionRatio < 1) {
-        scrollToActivatedTabButton();
+        scrollToActivatedTabItem();
       }
     });
 
-    activatedTabButton && intersectionObserver.observe(activatedTabButton);
+    activatedTabItem && intersectionObserver.observe(activatedTabItem);
 
-    /** tabHeader 스크롤시에는 활성화된 탭버튼으로 자동 스크롤되지 않도록 막아야한다. */
-    tabHeaderRef.current?.addEventListener('scroll', () => {
+    /** tabListRef 스크롤시에는 활성화된 탭버튼으로 자동 스크롤되지 않도록 막아야한다. */
+    tabListRef.current?.addEventListener('scroll', () => {
       intersectionObserver.disconnect();
     });
 
     return () => intersectionObserver.disconnect();
-  }, [activatedIndex, onChange, tabButtonRefs]);
+  }, [activatedIndex, onChange, tabItemRefs]);
 
   return (
     <StyledWrapper className={className}>
-      <StyledHeader ref={tabHeaderRef} size={size}>
+      <StyledTabList ref={tabListRef} size={size}>
         {tabItems.map((tabItem, index) => (
-          <StyledTabButton
-            ref={(element) => (tabButtonRefs.current[index] = element)}
+          <StyledTabItem
+            ref={(element) => (tabItemRefs.current[index] = element)}
             key={tabItem}
             isSelected={activatedIndex === index}
             onClick={() => setActivatedIndex(index)}
@@ -183,18 +173,14 @@ const Tab = ({
             isGhost={isGhost}
             size={size}
           >
-            {tabItem}
-          </StyledTabButton>
+            <button>{tabItem}</button>
+          </StyledTabItem>
         ))}
-      </StyledHeader>
-      <StyledCarousel
-        {...carouselInitialProps}
-        emulateTouch={isSwipable}
-        selectedItem={activatedIndex}
-        onChange={setActivatedIndex}
-      >
-        {children}
-      </StyledCarousel>
+      </StyledTabList>
+      {/**
+       * 배열인 경우 activatedIndex번째의 children을 렌더링하고,
+       * 배열이 아닌 경우 children을 그대로 랜더링한다. */}
+      {Array.isArray(children) ? children[activatedIndex] : children}
     </StyledWrapper>
   );
 };

--- a/src/components/Tab/index.ts
+++ b/src/components/Tab/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Tab';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4331,7 +4331,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.3.1:
+classnames@^2.2.5, classnames@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8764,7 +8764,7 @@ prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.6.0, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -8967,6 +8967,13 @@ react-draggable@^4.4.3:
     clsx "^1.1.1"
     prop-types "^15.6.0"
 
+react-easy-swipe@^0.0.21:
+  version "0.0.21"
+  resolved "https://registry.yarnpkg.com/react-easy-swipe/-/react-easy-swipe-0.0.21.tgz#ce9384d576f7a8529dc2ca377c1bf03920bac8eb"
+  integrity sha512-OeR2jAxdoqUMHIn/nS9fgreI5hSpgGoL5ezdal4+oO7YSSgJR8ga+PkYGJrSrJ9MKlPcQjMQXnketrD7WNmNsg==
+  dependencies:
+    prop-types "^15.5.8"
+
 react-element-to-jsx-string@^14.3.4:
   version "14.3.4"
   resolved "https://registry.yarnpkg.com/react-element-to-jsx-string/-/react-element-to-jsx-string-14.3.4.tgz#709125bc72f06800b68f9f4db485f2c7d31218a8"
@@ -9037,6 +9044,15 @@ react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
   integrity sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==
+
+react-responsive-carousel@^3.2.23:
+  version "3.2.23"
+  resolved "https://registry.yarnpkg.com/react-responsive-carousel/-/react-responsive-carousel-3.2.23.tgz#4c0016ff54603e604bb5c1f9e7ef2d1eda133f1d"
+  integrity sha512-pqJLsBaKHWJhw/ItODgbVoziR2z4lpcJg+YwmRlSk4rKH32VE633mAtZZ9kDXjy4wFO+pgUZmDKPsPe1fPmHCg==
+  dependencies:
+    classnames "^2.2.5"
+    prop-types "^15.5.8"
+    react-easy-swipe "^0.0.21"
 
 react-router-dom@^6.0.0:
   version "6.2.2"


### PR DESCRIPTION
## 📍 주요 변경사항

[스토리북](https://62472322b43dfc003a759108-jdccpwutqx.chromatic.com/?path=/story/components-tab--primary)

대륙 탭처럼 탭 길이가 길어지는 경우 해당 탭으로 자동 스크롤 되는 기능도 추가했습니다!

type: primary

<img width="537" alt="image" src="https://user-images.githubusercontent.com/39763891/167248731-ae31ab7b-264c-4e82-aa24-1816fcd6d1c0.png">

type: secondary

<img width="564" alt="image" src="https://user-images.githubusercontent.com/39763891/167248739-05790a92-2cda-48fe-a3b9-12325d8f0e2e.png">


## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

https://github.com/leandrowd/react-responsive-carousel

## 💡 중점적으로 봐주었으면 하는 부분

캐러셀 공용 컴포넌트를 추가할까도 했지만 라이브러리로 충분히 모듈화 되어있다고 생각되어 추가하지 않았습니다!

[수정] 생각해보니 모든 Tab을 Swiper로 만들면 안될 것 같아서 Swiper와 탭을 분리하였습니다!