### PR TITLE
feature: MultiSelect 및 field 컴포넌트 구현

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,6 +12,6 @@
       }
     ],
     "@typescript-eslint/no-unnecessary-type-constraint": "off",
-    "@typescript-eslint/no-explicit-any": "off"
+    "@typescript-eslint/no-explicit-any": "warn"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
         "newlines-between": "always"
       }
     ],
-    "@typescript-eslint/no-unnecessary-type-constraint": "off"
+    "@typescript-eslint/no-unnecessary-type-constraint": "off",
+    "@typescript-eslint/no-explicit-any": "off"
   }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
         "groups": ["builtin", "external", ["parent", "sibling"], "index"],
         "newlines-between": "always"
       }
-    ]
+    ],
+    "@typescript-eslint/no-unnecessary-type-constraint": "off"
   }
 }

--- a/src/components/ErrorMessage/ErrorMessage.stories.tsx
+++ b/src/components/ErrorMessage/ErrorMessage.stories.tsx
@@ -1,0 +1,15 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import ErrorMessage from './ErrorMessage';
+
+export default {
+  title: 'Components/ErrorMessage',
+  component: ErrorMessage,
+} as ComponentMeta<typeof ErrorMessage>;
+
+const Template: ComponentStory<typeof ErrorMessage> = (args) => <ErrorMessage {...args} />;
+
+export const BasicErrorMessage = Template.bind({});
+BasicErrorMessage.args = {
+  message: '에러났어요 ㅜㅜ',
+};

--- a/src/components/ErrorMessage/ErrorMessage.tsx
+++ b/src/components/ErrorMessage/ErrorMessage.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+interface ErrorMessageProps {
+  message: string;
+}
+
+const StyledErrorMessage = styled.div`
+  color: ${({ theme }) => theme.color.red};
+  font-size: 12px;
+  font-weight: 700;
+`;
+
+const ErrorMessage: React.FC<ErrorMessageProps> = ({ message }) => {
+  return <StyledErrorMessage>{message}</StyledErrorMessage>;
+};
+
+export default ErrorMessage;

--- a/src/components/ErrorMessage/index.ts
+++ b/src/components/ErrorMessage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ErrorMessage';

--- a/src/components/commons/TasteBox/TasteBox.tsx
+++ b/src/components/commons/TasteBox/TasteBox.tsx
@@ -30,7 +30,12 @@ const TasteBox = (props: BadgeProps) => {
       boxType={type}
       boxSize={size}
       boxWidth={width}
-      className={cx(`tasteBox--${type}`, `tasteBox--size-${size}`, className)}
+      className={cx(
+        `tasteBox--${type}`,
+        `tasteBox--size-${size}`,
+        onClick && 'tasteBox--cursor',
+        className,
+      )}
       onClick={onClick}
       {...attrs}
     >
@@ -52,6 +57,10 @@ const StyledTasteBox = styled.div<StyledBadgeProps>`
   font-weight: 700;
   font-size: 12px;
   line-height: 155.02%;
+
+  &.tasteBox--cursor {
+    cursor: pointer;
+  }
 
   &.tasteBox--primary {
     background-color: ${({ theme }) => theme.semanticColor.primary};

--- a/src/components/commons/TasteBox/TasteBox.tsx
+++ b/src/components/commons/TasteBox/TasteBox.tsx
@@ -57,6 +57,7 @@ const StyledTasteBox = styled.div<StyledBadgeProps>`
   font-weight: 700;
   font-size: 12px;
   line-height: 155.02%;
+  transition: background 0.3s;
 
   &.tasteBox--cursor {
     cursor: pointer;
@@ -84,6 +85,6 @@ const StyledTasteBox = styled.div<StyledBadgeProps>`
   }
   &.tasteBox--size-short {
     text-align: center;
-    width: calc(50% - 20px); //FixMe: 디자인 보고 조정 필요
+    width: calc(50% - 8px); //FixMe: 디자인 보고 조정 필요
   }
 `;

--- a/src/components/formFields/MultiSelectField/MultiSelect.stories.tsx
+++ b/src/components/formFields/MultiSelectField/MultiSelect.stories.tsx
@@ -32,7 +32,7 @@ const options = [
   { value: '5', label: '단맛과 쓴 맛이 어우러저요', key: '5' },
   { value: '6', label: '톡 쏘는 맛이 강해요', key: '6' },
   { value: '7', label: '탄 맛이 나요', key: '7' },
-  { value: '8', label: '깔끔한 맛이에요', key: '8' },
+  { value: '8', label: '깔끔한 맛이예요', key: '8' },
   { value: '9', label: '구수한 맛이 나요', key: '9' },
   { value: '10', label: '텁텁한 느낌이 있어요', key: '10' },
   { value: '11', label: '단 맛이 나요', key: '11' },
@@ -42,7 +42,7 @@ const options = [
   { value: '15', label: '단맛과 쓴 맛이 어우러저요', key: '15' },
   { value: '16', label: '톡 쏘는 맛이 강해요', key: '16' },
   { value: '17', label: '탄 맛이 나요', key: '17' },
-  { value: '18', label: '깔끔한 맛이에요', key: '18' },
+  { value: '18', label: '깔끔한 맛이예요', key: '18' },
   { value: '19', label: '구수한 맛이 나요', key: '19' },
   { value: '20', label: '텁텁한 느낌이 있어요', key: '20' },
 ];

--- a/src/components/formFields/MultiSelectField/MultiSelect.stories.tsx
+++ b/src/components/formFields/MultiSelectField/MultiSelect.stories.tsx
@@ -52,4 +52,5 @@ BasicMultiSelectField.args = {
   options,
   name: 'multiSelectField',
   height: '400px',
+  maxLength: 3,
 };

--- a/src/components/formFields/MultiSelectField/MultiSelect.stories.tsx
+++ b/src/components/formFields/MultiSelectField/MultiSelect.stories.tsx
@@ -1,0 +1,55 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import EntityForm from '@/components/EntityForm';
+
+import MultiSelectField from './MultiSelectField';
+
+export default {
+  title: 'FormFields/MultiSelectField',
+  component: MultiSelectField,
+  decorators: [
+    (Story) => (
+      <EntityForm onSubmit={action('onSubmit')}>
+        <div style={{ padding: '20px', backgroundColor: '#000' }}>
+          <Story />
+        </div>
+      </EntityForm>
+    ),
+  ],
+  argTypes: {
+    height: { control: 'text' },
+  },
+} as ComponentMeta<typeof MultiSelectField>;
+
+const Template: ComponentStory<typeof MultiSelectField> = (args) => <MultiSelectField {...args} />;
+
+const options = [
+  { value: '1', label: '단 맛이 나요', key: '1' },
+  { value: '2', label: '목넘김이 부드러워요', key: '2' },
+  { value: '3', label: '쓴 맛이 나요', key: '3' },
+  { value: '4', label: '향이 진하고 무거워요', key: '4' },
+  { value: '5', label: '단맛과 쓴 맛이 어우러저요', key: '5' },
+  { value: '6', label: '톡 쏘는 맛이 강해요', key: '6' },
+  { value: '7', label: '탄 맛이 나요', key: '7' },
+  { value: '8', label: '깔끔한 맛이에요', key: '8' },
+  { value: '9', label: '구수한 맛이 나요', key: '9' },
+  { value: '10', label: '텁텁한 느낌이 있어요', key: '10' },
+  { value: '11', label: '단 맛이 나요', key: '11' },
+  { value: '12', label: '목넘김이 부드러워요', key: '12' },
+  { value: '13', label: '쓴 맛이 나요', key: '13' },
+  { value: '14', label: '향이 진하고 무거워요', key: '14' },
+  { value: '15', label: '단맛과 쓴 맛이 어우러저요', key: '15' },
+  { value: '16', label: '톡 쏘는 맛이 강해요', key: '16' },
+  { value: '17', label: '탄 맛이 나요', key: '17' },
+  { value: '18', label: '깔끔한 맛이에요', key: '18' },
+  { value: '19', label: '구수한 맛이 나요', key: '19' },
+  { value: '20', label: '텁텁한 느낌이 있어요', key: '20' },
+];
+
+export const BasicMultiSelectField = Template.bind({});
+BasicMultiSelectField.args = {
+  options,
+  name: 'multiSelectField',
+  height: '400px',
+};

--- a/src/components/formFields/MultiSelectField/MultiSelect.tsx
+++ b/src/components/formFields/MultiSelectField/MultiSelect.tsx
@@ -1,0 +1,116 @@
+import React, { useCallback } from 'react';
+import styled from '@emotion/styled';
+
+import TasteBox from '@/components/commons/TasteBox';
+import { SelectOption } from '@/types/select';
+
+type ClickEvent = React.MouseEvent<HTMLDivElement, MouseEvent>;
+
+type ClickEventHandler<T> = (value: T[] | undefined, event: ClickEvent) => void;
+
+interface MultiSelectProps<T = any> {
+  options: SelectOption<T>[];
+  value: T[];
+  height?: string;
+  disabled?: boolean;
+  onChange?: ClickEventHandler<T>;
+}
+
+interface StyledMultiSelectProps {
+  boxHeight?: string;
+}
+
+const StyledMultiSelect = styled.div<StyledMultiSelectProps>`
+  position: relative;
+  height: ${({ boxHeight }) => boxHeight || 'fit-content'};
+
+  & .multi-select-list {
+    height: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    overflow-y: scroll;
+
+    -ms-overflow-style: none; /* IE and Edge */
+    scrollbar-width: none; /* Firefox */
+
+    &::-webkit-scrollbar {
+      display: none; /* Chrome, Safari, Opera*/
+    }
+  }
+
+  & .multi-select-item {
+    margin-bottom: 16px;
+  }
+
+  &::after {
+    position: absolute;
+    bottom: 0px;
+    left: 0;
+    height: 20px;
+    width: 100%;
+    content: ' ';
+    background: linear-gradient(
+      180deg,
+      ${({ theme }) => theme.color.whiteOpacity0},
+      ${({ theme }) => theme.color.black100} 100%
+    );
+  }
+`;
+
+const MultiSelect: React.FC<MultiSelectProps> = <T extends any>({
+  options,
+  value,
+  height,
+  disabled,
+  onChange,
+}: MultiSelectProps<T>) => {
+  const triggerChange = useCallback(
+    (value: T[] | undefined, e: ClickEvent) => {
+      if (!disabled) {
+        onChange?.(value, e);
+      }
+
+      return value;
+    },
+    [disabled, onChange],
+  );
+
+  const handleClick = useCallback(
+    (clickedValue: T, e: ClickEvent) => {
+      const hasValue = !!value?.includes(clickedValue);
+      const changedValue = [...(value || [])];
+
+      if (hasValue) {
+        const valueIndex = changedValue.findIndex((v) => v === value);
+        changedValue.splice(valueIndex, 1);
+      } else {
+        changedValue.push(clickedValue);
+      }
+
+      triggerChange(changedValue, e);
+    },
+    [value, triggerChange],
+  );
+
+  return (
+    <StyledMultiSelect boxHeight={height}>
+      <div className="multi-select-list">
+        {options.map((option) => (
+          <TasteBox
+            key={option.key}
+            aria-checked={!!value?.includes(option.value)}
+            type={value?.includes(option.value) ? 'primary' : 'default'}
+            size="short"
+            onClick={(e) => handleClick(option.value, e)}
+            className="multi-select-item"
+          >
+            {option.label}
+          </TasteBox>
+        ))}
+      </div>
+    </StyledMultiSelect>
+  );
+};
+
+export default MultiSelect;

--- a/src/components/formFields/MultiSelectField/MultiSelect.tsx
+++ b/src/components/formFields/MultiSelectField/MultiSelect.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
 import styled from '@emotion/styled';
+import { isNil } from 'lodash';
 
 import TasteBox from '@/components/commons/TasteBox';
 import { SelectOption } from '@/types/select';
@@ -11,9 +12,12 @@ type ClickEventHandler<T> = (value: T[] | undefined, event: ClickEvent) => void;
 interface MultiSelectProps<T = any> {
   options: SelectOption<T>[];
   value: T[];
+  maxLength?: number;
   height?: string;
   disabled?: boolean;
   onChange?: ClickEventHandler<T>;
+  setError?: (errorMessage: string) => void;
+  clearError?: () => void;
 }
 
 interface StyledMultiSelectProps {
@@ -61,9 +65,12 @@ const StyledMultiSelect = styled.div<StyledMultiSelectProps>`
 const MultiSelect: React.FC<MultiSelectProps> = <T extends any>({
   options,
   value,
+  maxLength,
   height,
   disabled,
   onChange,
+  setError,
+  clearError,
 }: MultiSelectProps<T>) => {
   const triggerChange = useCallback(
     (value: T[] | undefined, e: ClickEvent) => {
@@ -85,12 +92,16 @@ const MultiSelect: React.FC<MultiSelectProps> = <T extends any>({
         const valueIndex = changedValue.findIndex((v) => v === value);
         changedValue.splice(valueIndex, 1);
       } else {
+        if (!isNil(maxLength) && maxLength <= changedValue.length) {
+          setError?.(`${maxLength}개 까지만 선택할 수 있어요 ㅜㅜ`);
+          return;
+        }
         changedValue.push(clickedValue);
       }
-
+      clearError?.();
       triggerChange(changedValue, e);
     },
-    [value, triggerChange],
+    [value, triggerChange, maxLength, setError, clearError],
   );
 
   return (

--- a/src/components/formFields/MultiSelectField/MultiSelectField.tsx
+++ b/src/components/formFields/MultiSelectField/MultiSelectField.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+
+import MultiSelect from './MultiSelect';
+
+import { SelectOption } from '@/types/select';
+
+interface MultiSelectFieldProps<T = any> {
+  name: string;
+  options: SelectOption<T>[];
+  height?: string;
+}
+
+const MultiSelectField: React.FC<MultiSelectFieldProps> = <T extends any>({
+  name,
+  options,
+  height,
+}: MultiSelectFieldProps<T>) => {
+  const { control } = useFormContext();
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field: { value, onChange } }) => (
+        <MultiSelect options={options} value={value} onChange={onChange} height={height} />
+      )}
+    />
+  );
+};
+
+export default MultiSelectField;

--- a/src/components/formFields/MultiSelectField/MultiSelectField.tsx
+++ b/src/components/formFields/MultiSelectField/MultiSelectField.tsx
@@ -1,31 +1,66 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
+import styled from '@emotion/styled';
 
 import MultiSelect from './MultiSelect';
 
 import { SelectOption } from '@/types/select';
+import ErrorMessage from '@/components/ErrorMessage';
 
 interface MultiSelectFieldProps<T = any> {
   name: string;
   options: SelectOption<T>[];
   height?: string;
+  maxLength?: number;
 }
+
+const StyledMultiSelectField = styled.div``;
 
 const MultiSelectField: React.FC<MultiSelectFieldProps> = <T extends any>({
   name,
   options,
   height,
+  maxLength,
 }: MultiSelectFieldProps<T>) => {
-  const { control } = useFormContext();
+  const {
+    control,
+    setError,
+    formState: { errors },
+    clearErrors,
+  } = useFormContext();
+
+  const error = errors?.[name];
+
+  const handleSetError = useCallback(
+    (errorMessage: string) => {
+      setError(name, { message: errorMessage });
+    },
+    [name, setError],
+  );
+
+  const handleClearError = useCallback(() => {
+    clearErrors(name);
+  }, [name, clearErrors]);
 
   return (
-    <Controller
-      control={control}
-      name={name}
-      render={({ field: { value, onChange } }) => (
-        <MultiSelect options={options} value={value} onChange={onChange} height={height} />
-      )}
-    />
+    <StyledMultiSelectField>
+      <Controller
+        control={control}
+        name={name}
+        render={({ field: { value, onChange } }) => (
+          <MultiSelect
+            options={options}
+            value={value}
+            onChange={onChange}
+            height={height}
+            maxLength={maxLength}
+            setError={handleSetError}
+            clearError={handleClearError}
+          />
+        )}
+      />
+      {error && <ErrorMessage message={error?.message} />}
+    </StyledMultiSelectField>
   );
 };
 

--- a/src/components/formFields/MultiSelectField/index.ts
+++ b/src/components/formFields/MultiSelectField/index.ts
@@ -1,0 +1,1 @@
+export { default } from './MultiSelectField';

--- a/src/themes/Color.stories.tsx
+++ b/src/themes/Color.stories.tsx
@@ -117,6 +117,7 @@ const Template: ComponentStory<any> = () => {
         <ColorList colors={color} namespace="white" excludeNamespace="whiteOpacity" />
         <ColorList colors={color} namespace="blue" />
         <ColorList colors={color} namespace="yellow" />
+        <ColorList colors={color} namespace="red" />
         <ColorList colors={color} namespace="black" />
         <ColorList colors={color} namespace="whiteOpacity" />
       </section>

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -9,6 +9,7 @@ export const theme: Readonly<ColorTheme & FontTheme> = {
       blue: '#3E3BE6',
       yellow: '#FFD953',
       grey: '#989898',
+      red: '#ff3939', // TODO: 추후 에러 색상 확정되면 변경
 
       black100: '#000000',
       black80: '#323232',

--- a/src/themes/types.ts
+++ b/src/themes/types.ts
@@ -15,6 +15,7 @@ export type ColorToken =
   | 'blue'
   | 'yellow'
   | 'grey'
+  | 'red'
   | MakeTokenSet<'black', [100, 80]>
   | MakeTokenSet<'whiteOpacity', [80, 65, 50, 35, 20, 0]>;
 

--- a/src/types/select.d.ts
+++ b/src/types/select.d.ts
@@ -1,0 +1,8 @@
+import React from 'react';
+
+export interface SelectOption<T = any> {
+  value: T;
+  label: string;
+  key: React.Key;
+  disabled?: boolean;
+}


### PR DESCRIPTION
## 📍 주요 변경사항
- tasteBox 컴포넌트 스타일 변경
- MultiSelect 컴포넌트 구현
- MultiSelectField 컴포넌트 구현 (react-hook-form 형식)
- typescript 제네릭 문법 사용 시 any 타입을 상속받을 수 있도록 rule 추가
[스토리북 링크](https://62472322b43dfc003a759108-nppykxlxhr.chromatic.com/?path=/story/formfields-multiselectfield--basic-multi-select-field)

## 🔗 참고자료
<img width="409" alt="스크린샷 2022-05-08 오전 1 21 50" src="https://user-images.githubusercontent.com/49899406/167263055-7e1e7640-1fb9-4209-92e7-3fa936848b51.png">

## 💡 중점적으로 봐주었으면 하는 부분
- 우선 정확한 height 길이를 알지 않아서 추후에 설정하도록 string 값으로 받도록 설정했는데 피드백 부탁드립니다
- tasteBox 스타일도 변경해놓았는데 코드 부분에 코멘트 추가해놓을게요!
- storybook에서 확인하실 때 우측 상단에 분홍색 아이콘 클릭하시면 실제 값이 어떻게 변경되는지 확인하실 수 있습니다
