### PR TITLE
feat: ✨TextAreaField 컴포넌트 구현

### DIFF
--- a/src/components/formFields/TextAreaField/TextAreaField.stories.tsx
+++ b/src/components/formFields/TextAreaField/TextAreaField.stories.tsx
@@ -1,0 +1,41 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+
+import EntityForm from '@/components/EntityForm';
+
+import TextAreaField from './TextAreaField';
+
+export default {
+  title: 'FormFields/TextAreaField',
+  component: TextAreaField,
+  decorators: [
+    (Story) => (
+      <EntityForm onSubmit={action('onSubmit')}>
+        <div style={{ height: '100vh', padding: '20px', backgroundColor: '#000' }}>
+          <Story />
+        </div>
+      </EntityForm>
+    ),
+  ],
+  argTypes: {
+    width: { control: 'text' },
+    height: { control: 'text' },
+    className: { control: 'text' },
+  },
+} as ComponentMeta<typeof TextAreaField>;
+
+const Template: ComponentStory<typeof TextAreaField> = (args) => <TextAreaField {...args} />;
+
+export const BasicTextAreaField = Template.bind({});
+BasicTextAreaField.args = {
+  name: 'textAreaField',
+  width: '100%',
+  height: 'fit-content',
+};
+
+export const FullTextAreaField = Template.bind({});
+FullTextAreaField.args = {
+  name: 'textAreaField',
+  width: '100%',
+  height: '100%',
+};

--- a/src/components/formFields/TextAreaField/TextAreaField.tsx
+++ b/src/components/formFields/TextAreaField/TextAreaField.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import styled from '@emotion/styled';
+
+interface TextAreaFieldProps {
+  name: string;
+  width?: string;
+  height?: string;
+  className?: string;
+}
+
+interface StyledTextAreaProps {
+  boxWidth?: string;
+  boxHeight?: string;
+}
+
+export const StyledTextArea = styled.textarea<StyledTextAreaProps>`
+  background-color: ${({ theme }) => theme.color.whiteOpacity20};
+  color: ${({ theme }) => theme.color.whiteOpacity50};
+  width: ${({ boxWidth }) => boxWidth || '100%'};
+  height: ${({ boxHeight }) => boxHeight || 'fit-content'};
+  padding: 16px;
+  border-radius: 12px;
+  font-size: 14px;
+  line-height: 160%;
+`;
+
+const TextAreaField: React.FC<TextAreaFieldProps> = ({ name, width, height, className }) => {
+  const { control } = useFormContext();
+
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <StyledTextArea {...field} boxWidth={width} boxHeight={height} className={className} />
+      )}
+    />
+  );
+};
+
+export default TextAreaField;

--- a/src/components/formFields/TextAreaField/index.ts
+++ b/src/components/formFields/TextAreaField/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TextAreaField';


### PR DESCRIPTION
## 📍 주요 변경사항
- TextAreaField 컴포넌트 구현 (react-hook-form 용)
- width는 기본적으로 화면을 채우는 ui가 많을 것 같아 100%로 지정
- height는 각 페이지마다 다를 것 같아(현재는 입력페이지에만 있음) string값으로 입력받을 수 있도록 설정
[스토리북 링크](https://62472322b43dfc003a759108-zaoarymfut.chromatic.com/?path=/story/formfields-textareafield--basic-text-area-field)

## 🔗 참고자료
<img width="384" alt="스크린샷 2022-05-08 오후 12 54 07" src="https://user-images.githubusercontent.com/49899406/167281031-e82c2944-6f55-47f4-af9e-26f328a852e0.png">

## 💡 중점적으로 봐주었으면 하는 부분
