### PR TITLE
feat: ✨ Record 기록 첫 페이지 section 구현

### DIFF
--- a/src/containers/recordStepContainers/RecordFirstStepContainer/RecordFirstStepContainer.stories.tsx
+++ b/src/containers/recordStepContainers/RecordFirstStepContainer/RecordFirstStepContainer.stories.tsx
@@ -1,0 +1,26 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import RecordFirstStepContainer from './RecordFirstStepContainer';
+
+export default {
+  title: 'Pages/기록 페이지/RecordFirstStepContainer',
+  component: RecordFirstStepContainer,
+} as ComponentMeta<typeof RecordFirstStepContainer>;
+
+const Template: ComponentStory<typeof RecordFirstStepContainer> = (args) => (
+  <RecordFirstStepContainer {...args} />
+);
+
+export const Default = Template.bind({});
+Default.args = {
+  beerName: '제주 페일 에일',
+};
+
+Default.story = {
+  parameters: {
+    nextRouter: {
+      path: '/record?step=1',
+      asPath: '/record?step=1',
+    },
+  },
+};

--- a/src/containers/recordStepContainers/RecordFirstStepContainer/RecordFirstStepContainer.tsx
+++ b/src/containers/recordStepContainers/RecordFirstStepContainer/RecordFirstStepContainer.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+import EntityForm from '@/components/EntityForm';
+import EmojiRadioField from '@/components/formFields/EmojiRadioField';
+
+interface RecordFirstStepContainerProps {
+  beerName: string;
+  className?: string;
+  onSubmit: () => void;
+}
+
+const StyledRecordFirstStepContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  h2 {
+    ${({ theme }) => theme.fonts.H2}
+    text-align: center;
+    margin-bottom: 10px;
+  }
+
+  p.body-1 {
+    ${({ theme }) => theme.fonts.Body2}
+    color: ${({ theme }) => theme.semanticColor.secondary};
+    text-align: center;
+    margin-bottom: 100px;
+  }
+`;
+
+const RecordFirstStepContainer: React.FC<RecordFirstStepContainerProps> = ({
+  beerName,
+  className,
+  onSubmit,
+}) => {
+  return (
+    <StyledRecordFirstStepContainer className={className}>
+      <EntityForm onSubmit={onSubmit}>
+        <h2>{'이번 맥주는 어땠나요?'}</h2>
+        <p className="body-1">{beerName}</p>
+        <EmojiRadioField name="feel" />
+      </EntityForm>
+    </StyledRecordFirstStepContainer>
+  );
+};
+
+export default RecordFirstStepContainer;

--- a/src/containers/recordStepContainers/RecordFirstStepContainer/index.ts
+++ b/src/containers/recordStepContainers/RecordFirstStepContainer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RecordFirstStepContainer';


### PR DESCRIPTION
## 📍 주요 변경사항
- Record 기록 첫 페이지 section 구현

## 🔗 참고자료
<img width="353" alt="스크린샷 2022-05-19 오후 11 16 54" src="https://user-images.githubusercontent.com/49899406/169315630-de8886be-9734-4c68-9579-413cd45b3abd.png">

## 💡 중점적으로 봐주었으면 하는 부분
- header랑 footer쪽 버튼은 페이지에서 구현하고 해당 부분은 컨테이너 안에 컴포넌트로 놓고 swipe 넣을꺼라 section 부분만 넣었어요
