### PR TITLE
feat: CreateRecordPage api 연동 제외한 모든 기능 구현

### DIFF
--- a/src/components/EntityForm/EntityForm.tsx
+++ b/src/components/EntityForm/EntityForm.tsx
@@ -13,6 +13,7 @@ export interface EntityFormProps extends UseFormProps {
   onlyModifiedFields?: boolean;
   children?: React.ReactNode;
   footer?: React.ReactNode;
+  showDebug?: boolean;
   onSubmit: SubmitHandler<FieldValues>;
 }
 
@@ -20,6 +21,7 @@ const EntityForm: React.FC<EntityFormProps> = ({
   onlyModifiedFields = false,
   children,
   footer,
+  showDebug = true,
   onSubmit,
   ...useFormProps
 }: EntityFormProps) => {
@@ -48,7 +50,7 @@ const EntityForm: React.FC<EntityFormProps> = ({
         {children}
         {footer}
       </form>
-      <DevTool control={control} />
+      {showDebug && <DevTool control={control} />}
     </FormProvider>
   );
 };

--- a/src/components/EntityForm/EntityForm.tsx
+++ b/src/components/EntityForm/EntityForm.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import {
   FormProvider,
   useForm,
@@ -23,11 +23,12 @@ const EntityForm: React.FC<EntityFormProps> = ({
   onSubmit,
   ...useFormProps
 }: EntityFormProps) => {
-  const methods = useForm({ mode: 'onBlur', ...useFormProps });
+  const methods = useForm({ mode: 'onChange', ...useFormProps });
   const {
     control,
     handleSubmit: hookFormHandleSubmit,
     formState: { dirtyFields },
+    trigger,
   } = methods;
 
   const handleSubmit = useCallback(
@@ -36,6 +37,10 @@ const EntityForm: React.FC<EntityFormProps> = ({
     },
     [onSubmit, onlyModifiedFields, dirtyFields],
   );
+
+  useEffect(() => {
+    trigger();
+  }, [trigger]);
 
   return (
     <FormProvider {...methods}>

--- a/src/components/commons/Button/Button.tsx
+++ b/src/components/commons/Button/Button.tsx
@@ -14,12 +14,15 @@ type ButtonType =
   | 'default'
   | 'grey';
 
-interface ButtonProps {
+export type ButtonCount = 1 | 2 | 3 | 4 | 5 | 7 | 8 | 9;
+
+export interface ButtonProps {
   type?: ButtonType;
   htmlType?: 'button' | 'submit';
   line?: boolean;
   width?: 'small' | 'large' | string;
-  count?: 1 | 2 | 3 | 4 | 5 | 7 | 8 | 9;
+  maxWidth?: string;
+  count?: ButtonCount;
   leftAddon?: React.ReactNode;
   rightAddon?: React.ReactNode;
   disabled?: boolean;
@@ -32,6 +35,7 @@ interface ButtonProps {
 interface StyledButtonProps {
   buttonType: ButtonType;
   buttonWidth?: string;
+  buttonMaxWidth?: string;
   iconMargin: number;
 }
 
@@ -41,6 +45,7 @@ const Button: React.FC<ButtonProps> = ({
   line = false,
   disabled = false,
   width: _width,
+  maxWidth,
   count,
   className,
   leftAddon,
@@ -56,6 +61,7 @@ const Button: React.FC<ButtonProps> = ({
       buttonType={type}
       type={htmlType}
       buttonWidth={width}
+      buttonMaxWidth={maxWidth}
       disabled={disabled}
       className={cx([className, line && 'common-button-line'])}
       iconMargin={iconMargin}
@@ -123,6 +129,7 @@ const StyledButton = styled.button<StyledButtonProps>`
   align-items: center;
   transition: filter 0.2s;
   ${({ buttonWidth }) => (buttonWidth ? ` width: ${buttonWidth};` : '')}
+  ${({ buttonMaxWidth }) => (buttonMaxWidth ? ` max-width: ${buttonMaxWidth};` : '')}
 
   & > .common-button-icon-wrapper {
     height: 20px;

--- a/src/components/commons/Button/index.ts
+++ b/src/components/commons/Button/index.ts
@@ -1,1 +1,2 @@
 export { default } from './Button';
+export type { ButtonProps, ButtonCount } from './Button';

--- a/src/components/commons/FormSubmitButton/FormSubmitButton.tsx
+++ b/src/components/commons/FormSubmitButton/FormSubmitButton.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { useFormState } from 'react-hook-form';
+
+import Button, { ButtonProps } from '../Button';
+
+interface FormSubmitButtonProps extends ButtonProps {
+  autoDisabled?: boolean;
+}
+
+const FormSubmitButton: React.FC<FormSubmitButtonProps> = ({ autoDisabled = false, ...props }) => {
+  const { errors } = useFormState();
+
+  const hasError = !!Object.keys(errors).length;
+
+  return <Button {...props} disabled={autoDisabled ? hasError : undefined} />;
+};
+
+export default FormSubmitButton;

--- a/src/components/commons/FormSubmitButton/index.ts
+++ b/src/components/commons/FormSubmitButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FormSubmitButton';

--- a/src/components/formFields/ImageUploadField/ImageUploadField.tsx
+++ b/src/components/formFields/ImageUploadField/ImageUploadField.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import styled from '@emotion/styled';
 
@@ -11,6 +11,7 @@ interface ImageUploadFieldProps {
   name: string;
   title?: string;
   className?: string;
+  required?: boolean;
   uploadCallback?: (data: FormData) => Promise<any>;
 }
 
@@ -43,10 +44,13 @@ const ImageUploadField: React.FC<ImageUploadFieldProps> = ({
   name,
   title,
   className,
+  required,
   uploadCallback,
 }) => {
   const imageInputRef = useRef<HTMLInputElement>(null);
   const { control } = useFormContext();
+
+  const rules = useMemo(() => ({ required }), [required]);
 
   const handleClick = useCallback(() => {
     imageInputRef.current?.click();
@@ -73,6 +77,7 @@ const ImageUploadField: React.FC<ImageUploadFieldProps> = ({
     <Controller
       control={control}
       name={name}
+      rules={rules}
       render={({ field }) => (
         <StyledImageUploadField>
           <input

--- a/src/components/formFields/ImageUploadField/ImageUploadField.tsx
+++ b/src/components/formFields/ImageUploadField/ImageUploadField.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import styled from '@emotion/styled';
 
@@ -50,8 +50,6 @@ const ImageUploadField: React.FC<ImageUploadFieldProps> = ({
   const imageInputRef = useRef<HTMLInputElement>(null);
   const { control } = useFormContext();
 
-  const rules = useMemo(() => ({ required }), [required]);
-
   const handleClick = useCallback(() => {
     imageInputRef.current?.click();
   }, []);
@@ -77,7 +75,7 @@ const ImageUploadField: React.FC<ImageUploadFieldProps> = ({
     <Controller
       control={control}
       name={name}
-      rules={rules}
+      rules={{ required }}
       render={({ field }) => (
         <StyledImageUploadField>
           <input

--- a/src/components/formFields/MultiSelectField/MultiSelect.tsx
+++ b/src/components/formFields/MultiSelectField/MultiSelect.tsx
@@ -72,12 +72,14 @@ const MultiSelect: React.FC<MultiSelectProps> = <T extends any>({
 }: MultiSelectProps<T>) => {
   const triggerChange = useCallback(
     (value: T[] | undefined, e: ClickEvent) => {
+      const _value = value?.length !== 0 ? value : undefined;
+
       if (!disabled) {
-        onChange?.(value, e);
+        onChange?.(_value, e);
         onBlur?.();
       }
 
-      return value;
+      return _value;
     },
     [disabled, onChange, onBlur],
   );

--- a/src/components/formFields/MultiSelectField/MultiSelectField.tsx
+++ b/src/components/formFields/MultiSelectField/MultiSelectField.tsx
@@ -6,13 +6,13 @@ import { isNil } from 'lodash';
 import MultiSelect from './MultiSelect';
 
 import { SelectOption } from '@/types/select';
-import ErrorMessage from '@/components/ErrorMessage';
 
 interface MultiSelectFieldProps<T = any> {
   name: string;
   options: SelectOption<T>[];
   height?: string;
   maxLength?: number;
+  required?: boolean;
 }
 
 const StyledMultiSelectField = styled.div``;
@@ -22,15 +22,16 @@ const MultiSelectField: React.FC<MultiSelectFieldProps> = <T extends any>({
   options,
   height,
   maxLength,
+  required = false,
 }: MultiSelectFieldProps<T>) => {
   const { control } = useFormContext();
 
   const rules = useMemo(
     () =>
       !isNil(maxLength)
-        ? { validate: (value: T[]) => (value?.length || 0) <= maxLength }
-        : undefined,
-    [maxLength],
+        ? { validate: (value: T[]) => (value?.length || 0) <= maxLength, required }
+        : { required },
+    [maxLength, required],
   );
 
   return (

--- a/src/components/formFields/TextAreaField/TextAreaField.tsx
+++ b/src/components/formFields/TextAreaField/TextAreaField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 import styled from '@emotion/styled';
 
@@ -8,6 +8,7 @@ interface TextAreaFieldProps {
   height?: string;
   maxHeight?: string;
   placeholder?: string;
+  required?: boolean;
   className?: string;
 }
 
@@ -40,14 +41,18 @@ const TextAreaField: React.FC<TextAreaFieldProps> = ({
   height,
   maxHeight,
   placeholder,
+  required,
   className,
 }) => {
   const { control } = useFormContext();
+
+  const rules = useMemo(() => ({ required }), [required]);
 
   return (
     <Controller
       control={control}
       name={name}
+      rules={rules}
       render={({ field }) => (
         <StyledTextArea
           {...field}

--- a/src/containers/CreateRecordContainer/CreateRecordContainer.tsx
+++ b/src/containers/CreateRecordContainer/CreateRecordContainer.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { NextPage } from 'next';
 import styled from '@emotion/styled';
+import { RecoilRoot } from 'recoil';
 
 import RecordFirstStepContainer from './RecordFirstStepContainer';
 import RecordSecondStepContainer from './RecordSecondStepContainer';
@@ -28,12 +29,20 @@ const CreateRecordContainer: NextPage<CreateRecordContainerProps> = ({ beer }) =
     <StyledCreateRecordContainer>
       <Header leftExtras={<BackButton />} />
       <SwiperLayout className="record-layout">
-        <RecordFirstStepContainer beerName={beer.name!} onSubmit={() => null} />
-        <RecordSecondStepContainer beerName={beer.name!} onSubmit={() => null} />
-        <RecordThirdStepContainer beer={beer} onSubmit={() => null} />
+        <RecordFirstStepContainer beerName={beer.name!} />
+        <RecordSecondStepContainer beerName={beer.name!} />
+        <RecordThirdStepContainer beer={beer} />
       </SwiperLayout>
     </StyledCreateRecordContainer>
   );
 };
 
-export default CreateRecordContainer;
+const CreateRecordRecoilWrapper: NextPage<CreateRecordContainerProps> = (props) => {
+  return (
+    <RecoilRoot>
+      <CreateRecordContainer {...props} />
+    </RecoilRoot>
+  );
+};
+
+export default CreateRecordRecoilWrapper;

--- a/src/containers/CreateRecordContainer/CreateRecordContainer.tsx
+++ b/src/containers/CreateRecordContainer/CreateRecordContainer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NextPage } from 'next';
+import { NextPage, GetServerSideProps } from 'next';
 import styled from '@emotion/styled';
 import { RecoilRoot } from 'recoil';
 
@@ -7,6 +7,7 @@ import RecordFirstStepContainer from './RecordFirstStepContainer';
 import RecordSecondStepContainer from './RecordSecondStepContainer';
 import RecordThirdStepContainer from './RecordThirdStepContainer';
 
+import { Beers } from '@/constants/Beers';
 import { Beer } from '@/types/Beer';
 import Header from '@/components/Header';
 import { BackButton } from '@/components/Header/extras';
@@ -43,6 +44,15 @@ const CreateRecordRecoilWrapper: NextPage<CreateRecordContainerProps> = (props) 
       <CreateRecordContainer {...props} />
     </RecoilRoot>
   );
+};
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  return {
+    props: {
+      // TODO: 추후 api 연결
+      beer: Beers[1],
+    },
+  };
 };
 
 export default CreateRecordRecoilWrapper;

--- a/src/containers/CreateRecordContainer/RecordFirstStepContainer/RecordFirstStepContainer.tsx
+++ b/src/containers/CreateRecordContainer/RecordFirstStepContainer/RecordFirstStepContainer.tsx
@@ -1,16 +1,19 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import styled from '@emotion/styled';
+import { useSetRecoilState } from 'recoil';
+import { FieldValues } from 'react-hook-form';
+
+import { $recordForm } from '../atoms';
 
 import EntityForm from '@/components/EntityForm';
 import EmojiRadioField from '@/components/formFields/EmojiRadioField';
 import BottomFloatingButtonArea from '@/components/BottomFloatingButtonArea';
-import Button from '@/components/commons/Button';
+import FormSubmitButton from '@/components/commons/FormSubmitButton';
 import { SwiperLayoutChildProps } from '@/components/SwiperLayout';
 
 interface RecordFirstStepContainerProps extends SwiperLayoutChildProps {
   beerName: string;
   className?: string;
-  onSubmit: () => void;
 }
 
 const StyledRecordFirstStepContainer = styled.div`
@@ -33,23 +36,36 @@ const StyledRecordFirstStepContainer = styled.div`
   }
 `;
 
+const defaultValues = {
+  feel: 3,
+};
+
 const RecordFirstStepContainer: React.FC<RecordFirstStepContainerProps> = ({
   beerName,
   className,
   onMoveNext,
-  onSubmit,
 }) => {
+  const setRecordForm = useSetRecoilState($recordForm);
+
+  const handleSubmit = useCallback(
+    (data: FieldValues) => {
+      setRecordForm((prev) => ({ ...prev, ...data }));
+      onMoveNext?.();
+    },
+    [setRecordForm, onMoveNext],
+  );
+
   return (
     <StyledRecordFirstStepContainer className={className}>
-      <EntityForm onSubmit={onSubmit}>
+      <EntityForm onSubmit={handleSubmit} defaultValues={defaultValues}>
         <h2>{'이번 맥주는 어땠나요?'}</h2>
         <p className="body-2">{beerName}</p>
         <EmojiRadioField name="feel" />
         <BottomFloatingButtonArea
           button={
-            <Button type="primary" htmlType="submit" width="large" onClick={onMoveNext}>
+            <FormSubmitButton type="primary" htmlType="submit" width="large" autoDisabled>
               다음
-            </Button>
+            </FormSubmitButton>
           }
         />
       </EntityForm>

--- a/src/containers/CreateRecordContainer/RecordFirstStepContainer/RecordFirstStepContainer.tsx
+++ b/src/containers/CreateRecordContainer/RecordFirstStepContainer/RecordFirstStepContainer.tsx
@@ -57,7 +57,7 @@ const RecordFirstStepContainer: React.FC<RecordFirstStepContainerProps> = ({
 
   return (
     <StyledRecordFirstStepContainer className={className}>
-      <EntityForm onSubmit={handleSubmit} defaultValues={defaultValues}>
+      <EntityForm onSubmit={handleSubmit} defaultValues={defaultValues} showDebug={false}>
         <h2>{'이번 맥주는 어땠나요?'}</h2>
         <p className="body-2">{beerName}</p>
         <EmojiRadioField name="feel" />

--- a/src/containers/CreateRecordContainer/RecordSecondStepContainer/RecordSecondStepContainer.tsx
+++ b/src/containers/CreateRecordContainer/RecordSecondStepContainer/RecordSecondStepContainer.tsx
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import styled from '@emotion/styled';
+import { useRecoilState } from 'recoil';
+import { FieldValues } from 'react-hook-form';
 
+import { $recordForm } from '../atoms';
+
+import Emoji from '@/components/Emoji';
 import EntityForm from '@/components/EntityForm';
 import MultiSelectField from '@/components/formFields/MultiSelectField';
 import BottomFloatingButtonArea from '@/components/BottomFloatingButtonArea';
 import Button from '@/components/commons/Button';
+import FormSubmitButton from '@/components/commons/FormSubmitButton';
 import Icon from '@/components/commons/Icon';
 import { SwiperLayoutChildProps } from '@/components/SwiperLayout';
 
@@ -49,7 +55,6 @@ const StyledRecordSecondStepContainer = styled.div`
 interface RecordSecondStepContainerProps extends SwiperLayoutChildProps {
   beerName: string;
   className?: string;
-  onSubmit: () => void;
 }
 
 const RecordSecondStepContainer: React.FC<RecordSecondStepContainerProps> = ({
@@ -57,11 +62,20 @@ const RecordSecondStepContainer: React.FC<RecordSecondStepContainerProps> = ({
   className,
   onMovePrev,
   onMoveNext,
-  onSubmit,
 }) => {
+  const [{ feel }, setRecordForm] = useRecoilState($recordForm);
+
+  const handleSubmit = useCallback(
+    (data: FieldValues) => {
+      setRecordForm((prev) => ({ ...prev, ...data }));
+      onMoveNext?.();
+    },
+    [setRecordForm, onMoveNext],
+  );
+
   return (
     <StyledRecordSecondStepContainer className={className}>
-      <EntityForm onSubmit={onSubmit}>
+      <EntityForm onSubmit={handleSubmit} defaultValues={{ flavor: undefined }}>
         <h2>{'맥주 맛은 어땠나요?'}</h2>
         <p className="body-2">{beerName}</p>
         <p className="body-5">{'최대 3개까지 선택이 가능해요!'}</p>
@@ -70,54 +84,54 @@ const RecordSecondStepContainer: React.FC<RecordSecondStepContainerProps> = ({
           height="calc(100vh - 295px)"
           maxLength={3}
           options={dummyOptions}
+          required
         />
         <BottomFloatingButtonArea className="record-floating-area">
           <Button
             type="primary"
             line
-            htmlType="submit"
             onClick={onMovePrev}
             leftAddon={<Icon name="ArrowLeft" />}
             iconMargin={4}
           >
-            이전
+            {(feel && <Emoji feel={feel} size={20} />) || '이전'}
           </Button>
-          <Button
+          <FormSubmitButton
             type="primary"
             htmlType="submit"
-            onClick={onMoveNext}
             rightAddon={<Icon name="ArrowRight" />}
             iconMargin={4}
+            autoDisabled
           >
             다음
-          </Button>
+          </FormSubmitButton>
         </BottomFloatingButtonArea>
       </EntityForm>
     </StyledRecordSecondStepContainer>
   );
 };
 
-const dummyOptions = [
-  { value: '1', label: '단 맛이 나요', key: '1' },
-  { value: '2', label: '목넘김이 부드러워요', key: '2' },
-  { value: '3', label: '쓴 맛이 나요', key: '3' },
-  { value: '4', label: '향이 진하고 무거워요', key: '4' },
-  { value: '5', label: '단맛과 쓴 맛이 어우러저요', key: '5' },
-  { value: '6', label: '톡 쏘는 맛이 강해요', key: '6' },
-  { value: '7', label: '탄 맛이 나요', key: '7' },
-  { value: '8', label: '깔끔한 맛이예요', key: '8' },
-  { value: '9', label: '구수한 맛이 나요', key: '9' },
-  { value: '10', label: '텁텁한 느낌이 있어요', key: '10' },
-  { value: '11', label: '단 맛이 나요', key: '11' },
-  { value: '12', label: '목넘김이 부드러워요', key: '12' },
-  { value: '13', label: '쓴 맛이 나요', key: '13' },
-  { value: '14', label: '향이 진하고 무거워요', key: '14' },
-  { value: '15', label: '단맛과 쓴 맛이 어우러저요', key: '15' },
-  { value: '16', label: '톡 쏘는 맛이 강해요', key: '16' },
-  { value: '17', label: '탄 맛이 나요', key: '17' },
-  { value: '18', label: '깔끔한 맛이예요', key: '18' },
-  { value: '19', label: '구수한 맛이 나요', key: '19' },
-  { value: '20', label: '텁텁한 느낌이 있어요', key: '20' },
+export const dummyOptions = [
+  { value: 1, label: '단 맛이 나요', key: '1' },
+  { value: 2, label: '목넘김이 부드러워요', key: '2' },
+  { value: 3, label: '쓴 맛이 나요', key: '3' },
+  { value: 4, label: '향이 진하고 무거워요', key: '4' },
+  { value: 5, label: '단맛과 쓴 맛이 어우러저요', key: '5' },
+  { value: 6, label: '톡 쏘는 맛이 강해요', key: '6' },
+  { value: 7, label: '탄 맛이 나요', key: '7' },
+  { value: 8, label: '깔끔한 맛이예요', key: '8' },
+  { value: 9, label: '구수한 맛이 나요', key: '9' },
+  { value: 10, label: '텁텁한 느낌이 있어요', key: '10' },
+  { value: 11, label: '단 맛이 나요', key: '11' },
+  { value: 12, label: '목넘김이 부드러워요', key: '12' },
+  { value: 13, label: '쓴 맛이 나요', key: '13' },
+  { value: 14, label: '향이 진하고 무거워요', key: '14' },
+  { value: 15, label: '단맛과 쓴 맛이 어우러저요', key: '15' },
+  { value: 16, label: '톡 쏘는 맛이 강해요', key: '16' },
+  { value: 17, label: '탄 맛이 나요', key: '17' },
+  { value: 18, label: '깔끔한 맛이예요', key: '18' },
+  { value: 19, label: '구수한 맛이 나요', key: '19' },
+  { value: 20, label: '텁텁한 느낌이 있어요', key: '20' },
 ];
 
 export default RecordSecondStepContainer;

--- a/src/containers/CreateRecordContainer/RecordSecondStepContainer/RecordSecondStepContainer.tsx
+++ b/src/containers/CreateRecordContainer/RecordSecondStepContainer/RecordSecondStepContainer.tsx
@@ -94,7 +94,7 @@ const RecordSecondStepContainer: React.FC<RecordSecondStepContainerProps> = ({
             leftAddon={<Icon name="ArrowLeft" />}
             iconMargin={4}
           >
-            {(feel && <Emoji feel={feel} size={20} />) || '이전'}
+            {feel ? <Emoji feel={feel} size={20} /> : '이전'}
           </Button>
           <FormSubmitButton
             type="primary"

--- a/src/containers/CreateRecordContainer/RecordSecondStepContainer/RecordSecondStepContainer.tsx
+++ b/src/containers/CreateRecordContainer/RecordSecondStepContainer/RecordSecondStepContainer.tsx
@@ -75,7 +75,7 @@ const RecordSecondStepContainer: React.FC<RecordSecondStepContainerProps> = ({
 
   return (
     <StyledRecordSecondStepContainer className={className}>
-      <EntityForm onSubmit={handleSubmit} defaultValues={{ flavor: undefined }}>
+      <EntityForm onSubmit={handleSubmit} showDebug={false}>
         <h2>{'맥주 맛은 어땠나요?'}</h2>
         <p className="body-2">{beerName}</p>
         <p className="body-5">{'최대 3개까지 선택이 가능해요!'}</p>

--- a/src/containers/CreateRecordContainer/RecordThirdStepContainer/RecordThirdStepContainer.tsx
+++ b/src/containers/CreateRecordContainer/RecordThirdStepContainer/RecordThirdStepContainer.tsx
@@ -91,7 +91,7 @@ const RecordThirdStepContainer: React.FC<RecordThirdStepContainerProps> = ({
 
   return (
     <StyledRecordThirdStepContainer>
-      <EntityForm onSubmit={handleSubmit} defaultValues={defaultValues}>
+      <EntityForm onSubmit={handleSubmit} defaultValues={defaultValues} showDebug={false}>
         <h2>{'당신만의 맥주 이야기도 들려주세요'}</h2>
         <p className="body-1">{beer.name}</p>
         <ImageUploadField name="imageUrl" beer={beer} required />

--- a/src/containers/CreateRecordContainer/RecordThirdStepContainer/RecordThirdStepContainer.tsx
+++ b/src/containers/CreateRecordContainer/RecordThirdStepContainer/RecordThirdStepContainer.tsx
@@ -1,5 +1,10 @@
-import React from 'react';
+import React, { useCallback } from 'react';
 import styled from '@emotion/styled';
+import { useRecoilState } from 'recoil';
+import { FieldValues } from 'react-hook-form';
+
+import { $recordForm } from '../atoms';
+import { dummyOptions } from '../RecordSecondStepContainer/RecordSecondStepContainer';
 
 import { Beer } from '@/types/Beer';
 import EntityForm from '@/components/EntityForm';
@@ -7,14 +12,14 @@ import ImageUploadField from '@/components/formFields/ImageUploadField';
 import SelectField from '@/components/formFields/SelectField';
 import TextAreaField from '@/components/formFields/TextAreaField';
 import BottomFloatingButtonArea from '@/components/BottomFloatingButtonArea';
-import Button from '@/components/commons/Button';
+import Button, { ButtonCount } from '@/components/commons/Button';
+import FormSubmitButton from '@/components/commons/FormSubmitButton';
 import { SwiperLayoutChildProps } from '@/components/SwiperLayout';
 import Icon from '@/components/commons/Icon';
 
 interface RecordThirdStepContainerProps extends SwiperLayoutChildProps {
   beer: Beer;
   className?: string;
-  onSubmit: () => void;
 }
 
 const StyledRecordThirdStepContainer = styled.div`
@@ -62,18 +67,34 @@ const StyledRecordThirdStepContainer = styled.div`
   }
 `;
 
+const defaultValues = {
+  isPublic: false,
+};
+
 const RecordThirdStepContainer: React.FC<RecordThirdStepContainerProps> = ({
   beer,
   onMovePrev,
   onMoveNext,
-  onSubmit,
 }) => {
+  const [{ flavor }, setRecordForm] = useRecoilState($recordForm);
+
+  const handleSubmit = useCallback(
+    (data: FieldValues) => {
+      setRecordForm((prev) => ({ ...prev, ...data }));
+      onMoveNext?.();
+    },
+    [setRecordForm, onMoveNext],
+  );
+
+  const beforeText =
+    flavor?.[0] && dummyOptions.find((option) => Number(option.value) === flavor[0])?.label;
+
   return (
     <StyledRecordThirdStepContainer>
-      <EntityForm onSubmit={onSubmit}>
+      <EntityForm onSubmit={handleSubmit} defaultValues={defaultValues}>
         <h2>{'당신만의 맥주 이야기도 들려주세요'}</h2>
         <p className="body-1">{beer.name}</p>
-        <ImageUploadField name="imageUrl" beer={beer} />
+        <ImageUploadField name="imageUrl" beer={beer} required />
         <div className="switch-wrapper">
           <span>{'맥주 여행 소감 공개 여부'}</span>
           <SelectField name="isPublic" />
@@ -84,28 +105,31 @@ const RecordThirdStepContainer: React.FC<RecordThirdStepContainerProps> = ({
             maxHeight="calc(100vh - 391px)"
             height="230px"
             placeholder={`이번 맥주 여행은 어떠셨나요?\n맥주를 마실 때 맛이나 후기를 적어도 좋아요.\n혹은 분위기, 상황은 어땠는지 추억을 남겨보세요!`}
+            required
           />
         </div>
         <BottomFloatingButtonArea className="record-floating-area">
           <Button
             type="primary"
             line
-            htmlType="submit"
             onClick={onMovePrev}
             leftAddon={<Icon name="ArrowLeft" />}
             iconMargin={4}
+            count={flavor?.length as ButtonCount | undefined}
+            maxWidth="44vw"
           >
-            이전
+            {beforeText || '이전'}
           </Button>
-          <Button
+          <FormSubmitButton
             type="primary"
             htmlType="submit"
             onClick={onMoveNext}
             rightAddon={<Icon name="ArrowRight" />}
             iconMargin={4}
+            autoDisabled
           >
             다음
-          </Button>
+          </FormSubmitButton>
         </BottomFloatingButtonArea>
       </EntityForm>
     </StyledRecordThirdStepContainer>

--- a/src/containers/CreateRecordContainer/atoms/index.ts
+++ b/src/containers/CreateRecordContainer/atoms/index.ts
@@ -1,0 +1,1 @@
+export { default as $recordForm } from './recordFormAtom';

--- a/src/containers/CreateRecordContainer/atoms/recordFormAtom.ts
+++ b/src/containers/CreateRecordContainer/atoms/recordFormAtom.ts
@@ -1,0 +1,18 @@
+import { atom } from 'recoil';
+
+const ATOM_KEY = 'record-form';
+
+interface RecordFormAtom {
+  feel?: number;
+  flavor?: number[];
+  imageUrl?: string;
+  isPublic?: boolean;
+  content?: string;
+}
+
+const $recordForm = atom<RecordFormAtom>({
+  key: ATOM_KEY,
+  default: {},
+});
+
+export default $recordForm;

--- a/src/containers/CreateRecordContainer/index.tsx
+++ b/src/containers/CreateRecordContainer/index.tsx
@@ -1,1 +1,1 @@
-export { default } from './CreateRecordContainer';
+export { default, getServerSideProps } from './CreateRecordContainer';

--- a/src/pages/record/create.ts
+++ b/src/pages/record/create.ts
@@ -1,0 +1,1 @@
+export { default, getServerSideProps } from '@/containers/CreateRecordContainer';


### PR DESCRIPTION
## 📍 주요 변경사항
- 각 field 컴포넌트 validation 추가
- CreateRecord 페이지 상태 recoil 격리
- CreateRecord 페이지 next router 연결

## 🔗 참고자료
![May-24-2022 00-53-21](https://user-images.githubusercontent.com/49899406/169859208-99826d56-a7e6-4ea7-956a-574eca02be86.gif)

## 💡 중점적으로 봐주었으면 하는 부분
-
