### PR TITLE
feat: 맥주 추천, 반한 맥주 탭 목록 페이지

### DIFF
--- a/src/apis/beer.ts
+++ b/src/apis/beer.ts
@@ -80,6 +80,26 @@ export const getBeers = async (payload: IGetBeersPayload) => {
   return res.data;
 };
 
+export interface IGetBeersRecommendResponseData extends IBaseResponse<{ beers: IBeer[] }> {}
+
+/**
+ * 추천 맥주 목록 조회
+ */
+export const getBeersRecommend = async () => {
+  const res = await axios.get<IGetBeersRecommendResponseData>('/api/v1/beers/recommend');
+  return res.data;
+};
+
+export interface IGetBeersLikedResponseData extends IBaseResponse<{ beers: IBeer[] }> {}
+
+/**
+ * 찜한 맥주 목록 조회
+ */
+export const getBeersLiked = async () => {
+  const res = await axios.get<IGetBeersLikedResponseData>('/api/v1/beers/liked');
+  return res.data;
+};
+
 export interface IGetBeerResponseData extends IBaseResponse<IBeer> {}
 
 /**

--- a/src/components/BeerList/BeerList.stories.tsx
+++ b/src/components/BeerList/BeerList.stories.tsx
@@ -7,10 +7,6 @@ import { Beers } from '@/constants/Beers';
 export default {
   title: 'Components/BeerList',
   component: BeerList,
-  argTypes: {
-    type: { control: 'radio', options: ['grid', 'list'] },
-  },
-  args: {},
 } as ComponentMeta<typeof BeerList>;
 
 const Template: ComponentStory<typeof BeerList> = ({ ...args }) => (

--- a/src/components/BeerList/BeerList.tsx
+++ b/src/components/BeerList/BeerList.tsx
@@ -1,20 +1,22 @@
 import styled from '@emotion/styled';
+import { useRecoilValue } from 'recoil';
 
 import { IBeer } from '@/apis';
 import BeerGridItem from '@/components/beerItem/BeerGridItem';
 import BeerListItem from '@/components/beerItem/BeerListItem';
-import { BeerListViewType } from '@/recoil/atoms';
+import { $beerListViewType } from '@/recoil/atoms';
 
 interface Props {
-  type: BeerListViewType;
   beers: IBeer[];
 }
 
-const BeerList = ({ type = 'grid', beers, ...rest }: Props) => {
+const BeerList = ({ beers, ...rest }: Props) => {
+  const beerListViewType = useRecoilValue($beerListViewType);
+
   return (
-    <StyledBeerList className={type} {...rest}>
+    <StyledBeerList className={beerListViewType} {...rest}>
       {beers?.map((beer) =>
-        type === 'list' ? (
+        beerListViewType === 'list' ? (
           <BeerListItem key={beer.id} beer={beer} />
         ) : (
           <BeerGridItem key={beer.id} beer={beer} />

--- a/src/components/BeerList/BeerList.tsx
+++ b/src/components/BeerList/BeerList.tsx
@@ -3,10 +3,10 @@ import styled from '@emotion/styled';
 import { IBeer } from '@/apis';
 import BeerGridItem from '@/components/beerItem/BeerGridItem';
 import BeerListItem from '@/components/beerItem/BeerListItem';
-import { ListViewType } from '@/components/Header/extras/ListViewToggleButton';
+import { BeerListViewType } from '@/recoil/atoms';
 
 interface Props {
-  type: ListViewType;
+  type: BeerListViewType;
   beers: IBeer[];
 }
 
@@ -35,7 +35,7 @@ const StyledBeerList = styled.div`
     grid-template-columns: repeat(3, 1fr);
     grid-auto-rows: 1fr;
     gap: 26px 15px;
-    padding: 20px;
+    padding: 20px 20px 20vh;
   }
 
   &.list {
@@ -43,6 +43,6 @@ const StyledBeerList = styled.div`
     grid-template-columns: 1fr;
     grid-auto-rows: 1fr;
     gap: 16px;
-    padding: 20px 20px 20px 14px;
+    padding: 20px 20px 20vh 14px;
   }
 `;

--- a/src/components/BeerListPageHeader/BeerListPageHeader.tsx
+++ b/src/components/BeerListPageHeader/BeerListPageHeader.tsx
@@ -1,19 +1,13 @@
 import styled from '@emotion/styled';
-import { useRecoilState } from 'recoil';
 import { useRouter } from 'next/router';
 import { isNil } from 'lodash';
-import { MouseEvent, useEffect } from 'react';
+import { MouseEvent } from 'react';
 
 import Icon from '../commons/Icon';
 import Header from '../Header';
-import { BackButton, ListViewToggleButton } from '../Header/extras';
+import { BackButton, BeerListViewToggleButton } from '../Header/extras';
 
 import { ellipsis } from '@/styles/common';
-import {
-  $beerListViewType,
-  BEER_LIST_VIEW_ATOM_KEY,
-} from '@/containers/BeerListContainer/recoil/atoms';
-import QueryParams from '@/utils/query-params';
 
 const PLACEHOLDER_TEXT = '맥주 이름, 특징 검색';
 
@@ -46,17 +40,6 @@ const SearchBoxButton = styled.button<{ isPlaceHolder: boolean }>`
     }
   }
 `;
-
-const BeerListViewToggleButton = () => {
-  const [beerListViewType, setBeerListViewType] = useRecoilState($beerListViewType);
-
-  useEffect(() => {
-    const paramValue = QueryParams.get(BEER_LIST_VIEW_ATOM_KEY);
-    paramValue && setBeerListViewType(paramValue);
-  }, [setBeerListViewType]);
-
-  return <ListViewToggleButton type={beerListViewType} onChange={setBeerListViewType} />;
-};
 
 const SearchBox = () => {
   const router = useRouter();

--- a/src/components/BeerSearchResultList/BeerSearchResultList.tsx
+++ b/src/components/BeerSearchResultList/BeerSearchResultList.tsx
@@ -6,11 +6,8 @@ import { isNil } from 'lodash';
 import BeerList from '../BeerList';
 import BeerSearchResultEmpty from '../BeerSearchResultEmpty';
 
-import {
-  $beerListFilter,
-  $beerListSortBy,
-  $beerListViewType,
-} from '@/containers/BeerListContainer/recoil/atoms';
+import { $beerListFilter, $beerListSortBy } from '@/containers/BeerListContainer/recoil/atoms';
+import { $beerListViewType } from '@/recoil/atoms';
 import { getBeers } from '@/apis';
 
 const BeerSearchResultList = () => {

--- a/src/components/BeerSearchResultList/BeerSearchResultList.tsx
+++ b/src/components/BeerSearchResultList/BeerSearchResultList.tsx
@@ -7,14 +7,12 @@ import BeerList from '../BeerList';
 import BeerSearchResultEmpty from '../BeerSearchResultEmpty';
 
 import { $beerListFilter, $beerListSortBy } from '@/containers/BeerListContainer/recoil/atoms';
-import { $beerListViewType } from '@/recoil/atoms';
 import { getBeers } from '@/apis';
 
 const BeerSearchResultList = () => {
   const router = useRouter();
   const query = isNil(router.query.query) ? undefined : decodeURI(String(router.query.query));
 
-  const listViewType = useRecoilValue($beerListViewType);
   const filter = useRecoilValue($beerListFilter);
   const sortBy = useRecoilValue($beerListSortBy);
 
@@ -51,7 +49,7 @@ const BeerSearchResultList = () => {
     );
   }
 
-  return <BeerList type={listViewType} beers={beers} />;
+  return <BeerList beers={beers} />;
 };
 
 export default BeerSearchResultList;

--- a/src/components/BottomFloatingButtonArea/BottomFloatingButtonArea.tsx
+++ b/src/components/BottomFloatingButtonArea/BottomFloatingButtonArea.tsx
@@ -37,4 +37,5 @@ const StyledBottomFloatingButton = styled.div`
   width: 100%;
   height: 100px;
   background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, #000000 40.1%);
+  z-index: 1;
 `;

--- a/src/components/Header/Header.stories.tsx
+++ b/src/components/Header/Header.stories.tsx
@@ -4,7 +4,7 @@ import styled from '@emotion/styled';
 import {
   BackButton,
   CloseButton,
-  ListViewToggleButton,
+  BeerListViewToggleButton,
   OKTextButton,
   WriteButton,
   SaveButton,
@@ -52,7 +52,7 @@ export const 닫기_확인_헤더: ComponentStoryObj<typeof Header> = {
 export const 맥주_리스트_페이지: ComponentStoryObj<typeof Header> = {
   args: {
     leftExtras: <BackButton />,
-    rightExtras: <ListViewToggleButton type="grid" />,
+    rightExtras: <BeerListViewToggleButton />,
     children: '검색창 컴포넌트',
   },
 };

--- a/src/components/Header/extras/BeerListViewToggleButton.tsx
+++ b/src/components/Header/extras/BeerListViewToggleButton.tsx
@@ -1,13 +1,10 @@
 import styled from '@emotion/styled';
+import { useRecoilState } from 'recoil';
+import { useEffect } from 'react';
 
 import Icon from '@/components/commons/Icon';
-
-export type ListViewType = 'grid' | 'list';
-
-interface ListViewToggleButtonProps {
-  type: ListViewType;
-  onChange?: (type: ListViewType) => void;
-}
+import { $beerListViewType, BeerListViewType, BEER_LIST_VIEW_ATOM_KEY } from '@/recoil/atoms';
+import QueryParams from '@/utils/query-params';
 
 const StyledWrapper = styled.div`
   display: flex;
@@ -17,12 +14,16 @@ const StyledWrapper = styled.div`
   }
 `;
 
-const ListViewToggleButton = ({
-  type = 'grid',
-  onChange = () => null,
-}: ListViewToggleButtonProps) => {
-  const handleTypeChange = (value: ListViewType) => () => {
-    onChange(value);
+const BeerListViewToggleButton = () => {
+  const [type, setType] = useRecoilState($beerListViewType);
+
+  useEffect(() => {
+    const paramValue = QueryParams.get(BEER_LIST_VIEW_ATOM_KEY);
+    paramValue && setType(paramValue);
+  }, [setType]);
+
+  const handleTypeChange = (value: BeerListViewType) => () => {
+    setType(value);
   };
 
   const getIconColor = (isSelected: boolean) => {
@@ -41,4 +42,4 @@ const ListViewToggleButton = ({
   );
 };
 
-export default ListViewToggleButton;
+export default BeerListViewToggleButton;

--- a/src/components/Header/extras/extras.stories.tsx
+++ b/src/components/Header/extras/extras.stories.tsx
@@ -5,7 +5,7 @@ import {
   BackButton,
   CloseButton,
   LikeToggleButton,
-  ListViewToggleButton,
+  BeerListViewToggleButton,
   OKTextButton,
   SaveButton,
   WriteButton,
@@ -70,7 +70,7 @@ export const extras = () => {
           onUnLike={async () => alert('좋아요 해제')}
         />,
       )}
-      {renderExtra('ListViewToggleButton', <ListViewToggleButton type="grid" />)}
+      {renderExtra('BeerListViewToggleButton', <BeerListViewToggleButton />)}
       {renderExtra('OKTextButton', <OKTextButton />)}
       {renderExtra('SaveButton', <SaveButton />)}
       {renderExtra('WriteButton', <WriteButton />)}

--- a/src/components/Header/extras/index.tsx
+++ b/src/components/Header/extras/index.tsx
@@ -1,7 +1,7 @@
 export { default as BackButton } from './BackButton';
 export { default as CloseButton } from './CloseButton';
 export { default as LikeToggleButton } from './LikeToggleButton';
-export { default as ListViewToggleButton } from './ListViewToggleButton';
+export { default as BeerListViewToggleButton } from './BeerListViewToggleButton';
 export { default as OKTextButton } from './OKTextButton';
 export { default as SaveButton } from './SaveButton';
 export { default as ShareButton } from './ShareButton';

--- a/src/components/beerItem/BeerListItem/BeerListItem.tsx
+++ b/src/components/beerItem/BeerListItem/BeerListItem.tsx
@@ -111,9 +111,11 @@ const BeerName = styled.div`
   color: ${({ theme }) => theme.color.white};
   ${({ theme }) => theme.fonts.SubTitle4};
   ${ellipsis()};
+  text-align: left;
 `;
 
 const BeerInfo = styled.div`
   color: ${({ theme }) => theme.color.whiteOpacity80};
   ${({ theme }) => theme.fonts.SubTitle5};
+  text-align: left;
 `;

--- a/src/components/commons/Button/Button.tsx
+++ b/src/components/commons/Button/Button.tsx
@@ -132,8 +132,6 @@ const StyledButton = styled.button<StyledButtonProps>`
   ${({ buttonMaxWidth }) => (buttonMaxWidth ? ` max-width: ${buttonMaxWidth};` : '')}
 
   & > .common-button-icon-wrapper {
-    height: 20px;
-
     &.margin-right {
       margin-right: ${({ iconMargin }) => iconMargin}px;
     }

--- a/src/containers/BeerListContainer/recoil/atoms/index.ts
+++ b/src/containers/BeerListContainer/recoil/atoms/index.ts
@@ -1,3 +1,2 @@
 export * from './beerListFilter';
 export * from './beerListSortBy';
-export * from './beerListViewType';

--- a/src/containers/BeerRecommendAndLikedContainer/BeerRecommendAndLikedContainer.stories.tsx
+++ b/src/containers/BeerRecommendAndLikedContainer/BeerRecommendAndLikedContainer.stories.tsx
@@ -1,0 +1,20 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import BeerRecommendAndLikedContainer from './BeerRecommendAndLikedContainer';
+
+export default {
+  title: 'Pages/맥주 추천과 반한 맥주 목록',
+  component: BeerRecommendAndLikedContainer,
+  parameters: {
+    nextRouter: {
+      path: '/beer/recommend',
+    },
+  },
+} as ComponentMeta<typeof BeerRecommendAndLikedContainer>;
+
+const Template: ComponentStory<typeof BeerRecommendAndLikedContainer> = () => (
+  <BeerRecommendAndLikedContainer />
+);
+
+export const 맥주_추천과_반한_맥주_목록 = Template.bind({});
+맥주_추천과_반한_맥주_목록.args = {};

--- a/src/containers/BeerRecommendAndLikedContainer/BeerRecommendAndLikedContainer.tsx
+++ b/src/containers/BeerRecommendAndLikedContainer/BeerRecommendAndLikedContainer.tsx
@@ -14,16 +14,14 @@ import Swiper from '@/components/Swiper';
 import { useGetBeersLiked, useGetBeersRecommend } from '@/queries';
 import QueryParams from '@/utils/query-params';
 
-type HiType = 'recommend' | 'liked';
+type TabType = 'recommend' | 'liked';
 
-const hiToIndex = (hi: HiType): number => {
-  if (hi === 'liked') return 1;
-  return 0;
+const tabToIndex = (tab: TabType): number => {
+  return tab === 'liked' ? 1 : 0;
 };
 
-const indexToHi = (index: number): HiType => {
-  if (index === 1) return 'liked';
-  return 'recommend';
+const indexToTab = (index: number): TabType => {
+  return index === 1 ? 'liked' : 'recommend';
 };
 
 const TITLES = ['새로운 맥주를 도전해볼까요?', '예전에 찜해둔 맥주들이에요'];
@@ -80,8 +78,8 @@ const BeerRecommendButton = ({ onClick }: BeerRecommendButtonProps) => {
 };
 
 /**
- * hi="recommend" : 추천 맥주 목록
- * hi="liked" : 반한 맥주 목록
+ * tab="recommend" : 추천 맥주 목록
+ * tab="liked" : 반한 맥주 목록
  */
 const BeerRecommendAndLikedContainer = () => {
   const [activatedIndex, setActivatedIndex] = useActivatedIndex();
@@ -119,14 +117,14 @@ export default BeerRecommendAndLikedContainer;
 
 const useActivatedIndex = (): [number, Dispatch<SetStateAction<number>>] => {
   const {
-    query: { hi },
+    query: { tab },
   } = useRouter();
-  const parsedHi = !isNil(hi) ? JSON.parse(hi.toString()) : undefined;
+  const parsedTab = !isNil(tab) ? JSON.parse(tab.toString()) : undefined;
 
-  const [activatedIndex, setActivatedIndex] = useState(hiToIndex(parsedHi));
+  const [activatedIndex, setActivatedIndex] = useState(tabToIndex(parsedTab));
 
   useEffect(() => {
-    QueryParams.set('hi', indexToHi(activatedIndex));
+    QueryParams.set('tab', indexToTab(activatedIndex));
   }, [activatedIndex]);
 
   return [activatedIndex, setActivatedIndex];

--- a/src/containers/BeerRecommendAndLikedContainer/BeerRecommendAndLikedContainer.tsx
+++ b/src/containers/BeerRecommendAndLikedContainer/BeerRecommendAndLikedContainer.tsx
@@ -1,0 +1,133 @@
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import styled from '@emotion/styled';
+import { useRouter } from 'next/router';
+import { isNil } from 'lodash';
+
+import Header from '@/components/Header';
+import { BackButton, BeerListViewToggleButton } from '@/components/Header/extras';
+import Tab from '@/components/Tab';
+import BeerList from '@/components/BeerList';
+import BottomFloatingButtonArea from '@/components/BottomFloatingButtonArea';
+import Button from '@/components/commons/Button';
+import Icon from '@/components/commons/Icon';
+import Swiper from '@/components/Swiper';
+import { useGetBeersLiked, useGetBeersRecommend } from '@/queries';
+import QueryParams from '@/utils/query-params';
+
+type HiType = 'recommend' | 'liked';
+
+const hiToIndex = (hi: HiType): number => {
+  if (hi === 'liked') return 1;
+  return 0;
+};
+
+const indexToHi = (index: number): HiType => {
+  if (index === 1) return 'liked';
+  return 'recommend';
+};
+
+const TITLES = ['새로운 맥주를 도전해볼까요?', '예전에 찜해둔 맥주들이에요'];
+const TAB_ITEMS = ['안 마셔본 맥주', '반한 맥주'];
+
+const StyledFixedArea = styled.div`
+  position: sticky;
+  top: 0;
+  left: 0;
+  z-index: 2;
+  padding-bottom: 10px;
+  background: ${(p) =>
+    `linear-gradient(180deg, ${p.theme.semanticColor.background} 93%, rgba(0, 0, 0, 0) 100%)`};
+`;
+
+const StyledTitle = styled.h1`
+  padding: 10px 20px;
+  ${(p) => p.theme.fonts.H1};
+`;
+
+const StyledSwiper = styled(Swiper)`
+  flex: 1;
+  overflow-y: auto;
+
+  .carousel-slider,
+  .slider-wrapper,
+  .slider,
+  .slide {
+    height: 100%;
+  }
+
+  .slide {
+    overflow-y: auto;
+  }
+`;
+
+interface BeerRecommendButtonProps {
+  onClick: () => void;
+}
+
+const BeerRecommendButton = ({ onClick }: BeerRecommendButtonProps) => {
+  return (
+    <BottomFloatingButtonArea>
+      <Button
+        type="primary"
+        width="large"
+        leftAddon={<Icon name="Random" size={30} />}
+        onClick={onClick}
+      >
+        다른 맥주 추천 받기
+      </Button>
+    </BottomFloatingButtonArea>
+  );
+};
+
+/**
+ * hi="recommend" : 추천 맥주 목록
+ * hi="liked" : 반한 맥주 목록
+ */
+const BeerRecommendAndLikedContainer = () => {
+  const [activatedIndex, setActivatedIndex] = useActivatedIndex();
+
+  const { contents: beersRecommend, refetch: refetchBeersRecommend } = useGetBeersRecommend();
+  const { contents: beersLiked } = useGetBeersLiked();
+
+  const handleRecommendClick = () => {
+    refetchBeersRecommend();
+    window.scrollTo({ top: 0 });
+  };
+
+  return (
+    <>
+      <StyledFixedArea>
+        <Header leftExtras={<BackButton />} rightExtras={<BeerListViewToggleButton />} />
+        <StyledTitle>{TITLES[activatedIndex]}</StyledTitle>
+        <Tab
+          tabItems={TAB_ITEMS}
+          type="secondary"
+          outerActivatedIndex={activatedIndex}
+          onChange={setActivatedIndex}
+        />
+      </StyledFixedArea>
+      <StyledSwiper selectedItem={activatedIndex} onChange={setActivatedIndex}>
+        <BeerList beers={beersRecommend?.beers || []} />
+        <BeerList beers={beersLiked?.beers || []} />
+      </StyledSwiper>
+      {activatedIndex === 0 && <BeerRecommendButton onClick={handleRecommendClick} />}
+    </>
+  );
+};
+
+export default BeerRecommendAndLikedContainer;
+
+const useActivatedIndex = (): [number, Dispatch<SetStateAction<number>>] => {
+  const {
+    query: { hi },
+  } = useRouter();
+  const parsedHi = !isNil(hi) ? JSON.parse(hi.toString()) : undefined;
+
+  const [activatedIndex, setActivatedIndex] = useState(hiToIndex(parsedHi));
+
+  useEffect(() => {
+    QueryParams.set('hi', indexToHi(activatedIndex));
+  }, [activatedIndex]);
+
+  return [activatedIndex, setActivatedIndex];
+};

--- a/src/containers/BeerRecommendAndLikedContainer/index.ts
+++ b/src/containers/BeerRecommendAndLikedContainer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './BeerRecommendAndLikedContainer';

--- a/src/pages/beer/recommend-and-liked.tsx
+++ b/src/pages/beer/recommend-and-liked.tsx
@@ -1,0 +1,7 @@
+import BeerRecommendAndLikedContainer from '@/containers/BeerRecommendAndLikedContainer';
+
+const BeerRecommendAndLikedPage = () => {
+  return <BeerRecommendAndLikedContainer />;
+};
+
+export default BeerRecommendAndLikedPage;

--- a/src/queries/index.ts
+++ b/src/queries/index.ts
@@ -1,2 +1,4 @@
+export * from './useGetBeersLiked';
+export * from './useGetBeersRecommend';
 export * from './useGetBeerTypes';
 export * from './useGetCountries';

--- a/src/queries/useGetBeersLiked.ts
+++ b/src/queries/useGetBeersLiked.ts
@@ -1,0 +1,12 @@
+import { useQuery } from 'react-query';
+
+import { getBeersLiked } from '@/apis';
+
+export const useGetBeersLiked = () => {
+  const result = useQuery('beersLiked', () => getBeersLiked());
+
+  return {
+    ...result,
+    contents: result.data?.contents,
+  };
+};

--- a/src/queries/useGetBeersRecommend.ts
+++ b/src/queries/useGetBeersRecommend.ts
@@ -1,0 +1,12 @@
+import { useQuery } from 'react-query';
+
+import { getBeersRecommend } from '@/apis';
+
+export const useGetBeersRecommend = () => {
+  const result = useQuery('beersRecommend', getBeersRecommend);
+
+  return {
+    ...result,
+    contents: result.data?.contents,
+  };
+};

--- a/src/recoil/atoms/beerListViewType.ts
+++ b/src/recoil/atoms/beerListViewType.ts
@@ -1,11 +1,12 @@
 import { atom } from 'recoil';
 
-import { ListViewType } from '@/components/Header/extras/ListViewToggleButton';
 import { urlSyncRecoilEffect } from '@/recoil/effects';
 
 export const BEER_LIST_VIEW_ATOM_KEY = 'beer-list-view-type';
 
-export const $beerListViewType = atom<ListViewType>({
+export type BeerListViewType = 'grid' | 'list';
+
+export const $beerListViewType = atom<BeerListViewType>({
   key: BEER_LIST_VIEW_ATOM_KEY,
   default: 'grid',
   effects: [urlSyncRecoilEffect(BEER_LIST_VIEW_ATOM_KEY)],

--- a/src/recoil/atoms/index.ts
+++ b/src/recoil/atoms/index.ts
@@ -1,1 +1,2 @@
+export * from './beerListViewType';
 export { default as $searchHistories } from './searchHistories';


### PR DESCRIPTION
## 📍 주요 변경사항
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->
 맥주 추천, 반한 맥주 탭 목록 페이지

hi="recommend"
<img width="401" alt="image" src="https://user-images.githubusercontent.com/39763891/172149102-e1777fab-b915-4c71-8c85-8641715a8fe6.png">

hi="liked" (백엔드 mock 데이터 없음)
<img width="407" alt="image" src="https://user-images.githubusercontent.com/39763891/172149169-4ec3e179-d66f-4cae-a431-e6bf373d8e78.png">


- 맥주 리스트 뷰 타입을 beerListViewType atom으로 관리하도록 수정했습니다
- 자잘한 css 수정을 했습니다 [bf32ac2](https://github.com/depromeet/sulsul-FE/pull/91/commits/bf32ac20128c4c995b15ed8242f21269b7d75eb5), [366a9f2](https://github.com/depromeet/sulsul-FE/pull/91/commits/366a9f26924257c12ce39991eb656c2edb15dcfe), [e8431a5](https://github.com/depromeet/sulsul-FE/pull/91/commits/e8431a5c54c2c8287162aa33cd08a89d38a0819a)


## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->


## 💡 중점적으로 봐주었으면 하는 부분
<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

url이 `/beer/recommend-and-liked`입니다.
추천 맥주 목록과 반한 맥주 목록이 둘다 있는 페이지라서 path 네이밍이 어렵네요,, 

