### PR TITLE
feat: ga 초기 설정 및 각 페이지별 view 측정

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "gradient-string": "^2.0.1",
     "lodash": "^4.17.21",
     "next": "12.1.2",
+    "next-seo": "^5.4.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-hook-form": "^7.30.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@storybook/testing-library": "^0.0.9",
     "@svgr/webpack": "^5.5.0",
     "@types/gradient-string": "^1.1.2",
+    "@types/gtag.js": "^0.0.10",
     "@types/lodash": "^4.14.182",
     "@types/node": "^17.0.25",
     "@types/react": "^17.0.2",

--- a/src/components/GTagScript/GTagScript.tsx
+++ b/src/components/GTagScript/GTagScript.tsx
@@ -1,0 +1,22 @@
+import { gaMeasurementId } from '@/configs/ga';
+
+const GTagScript: React.FC = () => {
+  return (
+    <>
+      <script async src={`https://www.googletagmanager.com/gtag/js?id=${gaMeasurementId}`}></script>
+      <script
+        dangerouslySetInnerHTML={{
+          __html: `
+                window.dataLayer = window.dataLayer || [];
+                function gtag(){dataLayer.push(arguments);}
+                gtag('js', new Date());
+
+                gtag('config', '${gaMeasurementId}', { 'debug_mode': true });
+              `,
+        }}
+      />
+    </>
+  );
+};
+
+export default GTagScript;

--- a/src/components/GTagScript/index.ts
+++ b/src/components/GTagScript/index.ts
@@ -1,0 +1,1 @@
+export { default } from './GTagScript';

--- a/src/configs/ga.ts
+++ b/src/configs/ga.ts
@@ -1,1 +1,2 @@
-export const gaMeasurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || '';
+export const gaMeasurementId: string =
+  (process.env.NODE_ENV === 'production' ? process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID : '') ?? '';

--- a/src/configs/ga.ts
+++ b/src/configs/ga.ts
@@ -1,0 +1,1 @@
+export const gaMeasurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || '';

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export { default as PAGE_TITLES } from './page-titles';

--- a/src/constants/page-titles.ts
+++ b/src/constants/page-titles.ts
@@ -1,0 +1,18 @@
+const PAGE_TITLES = {
+  CREATE_RECORD: '기록하기',
+  BEER_RECOMMEND: '추천 맥주 목록',
+  LIKED: '반한 맥주 목록',
+  BEER_REQUEST_COMPLETE: '맥주요청 완료',
+  BEER_DETAIL: '맥주 상세정보',
+  BEER_LIST: '맥주 목록',
+  ETC: '프로필: 기타',
+  HOME: '홈',
+  LOGIN: '로그인',
+  ON_BOARDING: '시작하기',
+  PRIVACY_POLICY: '개인정보 처리방침',
+  PROFILE: '프로필',
+  TEAM: '팀원 소개',
+  TERMS_OF_SERVICE: '이용약관',
+};
+
+export default PAGE_TITLES;

--- a/src/containers/BeerRecommendAndLikedContainer/BeerRecommendAndLikedContainer.stories.tsx
+++ b/src/containers/BeerRecommendAndLikedContainer/BeerRecommendAndLikedContainer.stories.tsx
@@ -12,9 +12,16 @@ export default {
   },
 } as ComponentMeta<typeof BeerRecommendAndLikedContainer>;
 
-const Template: ComponentStory<typeof BeerRecommendAndLikedContainer> = () => (
-  <BeerRecommendAndLikedContainer />
+const Template: ComponentStory<typeof BeerRecommendAndLikedContainer> = (args) => (
+  <BeerRecommendAndLikedContainer {...args} />
 );
 
-export const 맥주_추천과_반한_맥주_목록 = Template.bind({});
-맥주_추천과_반한_맥주_목록.args = {};
+export const 맥주_추천_목록 = Template.bind({});
+맥주_추천_목록.args = {
+  activatedIndex: 0,
+};
+
+export const 반한_맥주_목록 = Template.bind({});
+반한_맥주_목록.args = {
+  activatedIndex: 1,
+};

--- a/src/containers/BeerRecommendAndLikedContainer/BeerRecommendAndLikedContainer.tsx
+++ b/src/containers/BeerRecommendAndLikedContainer/BeerRecommendAndLikedContainer.tsx
@@ -1,7 +1,4 @@
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import styled from '@emotion/styled';
-import { useRouter } from 'next/router';
-import { isNil } from 'lodash';
 
 import Header from '@/components/Header';
 import { BackButton, BeerListViewToggleButton } from '@/components/Header/extras';
@@ -12,17 +9,6 @@ import Button from '@/components/commons/Button';
 import Icon from '@/components/commons/Icon';
 import Swiper from '@/components/Swiper';
 import { useGetBeersLiked, useGetBeersRecommend } from '@/queries';
-import QueryParams from '@/utils/query-params';
-
-type TabType = 'recommend' | 'liked';
-
-const tabToIndex = (tab: TabType): number => {
-  return tab === 'liked' ? 1 : 0;
-};
-
-const indexToTab = (index: number): TabType => {
-  return index === 1 ? 'liked' : 'recommend';
-};
 
 const TITLES = ['새로운 맥주를 도전해볼까요?', '예전에 찜해둔 맥주들이에요'];
 const TAB_ITEMS = ['안 마셔본 맥주', '반한 맥주'];
@@ -77,13 +63,15 @@ const BeerRecommendButton = ({ onClick }: BeerRecommendButtonProps) => {
   );
 };
 
-/**
- * tab="recommend" : 추천 맥주 목록
- * tab="liked" : 반한 맥주 목록
- */
-const BeerRecommendAndLikedContainer = () => {
-  const [activatedIndex, setActivatedIndex] = useActivatedIndex();
+interface BeerRecommendAndLikedContainerProps {
+  activatedIndex: number;
+  setActivatedIndex: (activatedIndex: number) => void;
+}
 
+const BeerRecommendAndLikedContainer: React.FC<BeerRecommendAndLikedContainerProps> = ({
+  activatedIndex,
+  setActivatedIndex,
+}) => {
   const { contents: beersRecommend, refetch: refetchBeersRecommend } = useGetBeersRecommend();
   const { contents: beersLiked } = useGetBeersLiked();
 
@@ -114,18 +102,3 @@ const BeerRecommendAndLikedContainer = () => {
 };
 
 export default BeerRecommendAndLikedContainer;
-
-const useActivatedIndex = (): [number, Dispatch<SetStateAction<number>>] => {
-  const {
-    query: { tab },
-  } = useRouter();
-  const parsedTab = !isNil(tab) ? JSON.parse(tab.toString()) : undefined;
-
-  const [activatedIndex, setActivatedIndex] = useState(tabToIndex(parsedTab));
-
-  useEffect(() => {
-    QueryParams.set('tab', indexToTab(activatedIndex));
-  }, [activatedIndex]);
-
-  return [activatedIndex, setActivatedIndex];
-};

--- a/src/containers/CreateRecordContainer/CreateRecordContainer.tsx
+++ b/src/containers/CreateRecordContainer/CreateRecordContainer.tsx
@@ -13,6 +13,7 @@ import { BackButton } from '@/components/Header/extras';
 import { IBeer } from '@/apis';
 import SwiperLayout from '@/components/layouts/SwiperLayout';
 import { useGtagPageView } from '@/hooks';
+import { PAGE_TITLES } from '@/constants';
 
 interface CreateRecordContainerProps {
   beer: IBeer;
@@ -40,7 +41,7 @@ const CreateRecordContainer: NextPage<CreateRecordContainerProps> = ({ beer }) =
 };
 
 const CreateRecordRecoilWrapper: NextPage<CreateRecordContainerProps> = (props) => {
-  useGtagPageView('기록하기');
+  useGtagPageView(PAGE_TITLES.CREATE_RECORD);
 
   return (
     <RecoilRoot>

--- a/src/containers/CreateRecordContainer/CreateRecordContainer.tsx
+++ b/src/containers/CreateRecordContainer/CreateRecordContainer.tsx
@@ -12,6 +12,7 @@ import Header from '@/components/Header';
 import { BackButton } from '@/components/Header/extras';
 import { IBeer } from '@/apis';
 import SwiperLayout from '@/components/layouts/SwiperLayout';
+import { useGtagPageView } from '@/hooks';
 
 interface CreateRecordContainerProps {
   beer: IBeer;
@@ -39,6 +40,8 @@ const CreateRecordContainer: NextPage<CreateRecordContainerProps> = ({ beer }) =
 };
 
 const CreateRecordRecoilWrapper: NextPage<CreateRecordContainerProps> = (props) => {
+  useGtagPageView('기록하기');
+
   return (
     <RecoilRoot>
       <CreateRecordContainer {...props} />

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useElementSize } from './useElementSize';
+export { default as useGtagPageView } from './useGtagPageView';
 export { default as useSearchHistory } from './useSearchHistory';
 export { default as useModal } from './useModal';

--- a/src/hooks/useGtagPageView.ts
+++ b/src/hooks/useGtagPageView.ts
@@ -1,14 +1,16 @@
 import { useEffect } from 'react';
 
 import { gaMeasurementId } from '@/configs/ga';
+import { PAGE_TITLES } from '@/constants';
 
-const useGtagPageView = (pageTitle?: string) => {
+type PageTitleType = typeof PAGE_TITLES[keyof typeof PAGE_TITLES];
+
+const useGtagPageView = (pageTitle: PageTitleType) => {
   useEffect(() => {
-    const { title } = window.document;
     const { href, pathname } = window.location;
 
     window.gtag('config', gaMeasurementId, {
-      page_title: pageTitle || title,
+      page_title: pageTitle,
       page_location: href,
       page_path: pathname,
     });

--- a/src/hooks/useGtagPageView.ts
+++ b/src/hooks/useGtagPageView.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+import { gaMeasurementId } from '@/configs/ga';
+
+const useGtagPageView = (pageTitle?: string) => {
+  useEffect(() => {
+    const { title } = window.document;
+    const { href, pathname } = window.location;
+
+    window.gtag('config', gaMeasurementId, {
+      page_title: pageTitle || title,
+      page_location: href,
+      page_path: pathname,
+    });
+  }, []);
+};
+
+export default useGtagPageView;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -2,6 +2,7 @@ import { ThemeProvider } from '@emotion/react';
 import { RecoilRoot } from 'recoil';
 import type { AppProps } from 'next/app';
 import { QueryClientProvider } from 'react-query';
+import { NextSeo } from 'next-seo';
 
 import awesome from '@/utils/awesome';
 import { theme, GlobalStyle } from '@/themes';
@@ -12,16 +13,19 @@ awesome();
 
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <RecoilRoot>
-      <QueryClientProvider client={queryClient}>
-        <ThemeProvider theme={theme}>
-          <GlobalStyle theme={theme} />
-          <MainLayout>
-            <Component {...pageProps} />
-          </MainLayout>
-        </ThemeProvider>
-      </QueryClientProvider>
-    </RecoilRoot>
+    <>
+      <NextSeo title="맥주로 떠나는 세계 여행 | BeerAir" description="맥주로 떠나는 세계 여행" />
+      <RecoilRoot>
+        <QueryClientProvider client={queryClient}>
+          <ThemeProvider theme={theme}>
+            <GlobalStyle theme={theme} />
+            <MainLayout>
+              <Component {...pageProps} />
+            </MainLayout>
+          </ThemeProvider>
+        </QueryClientProvider>
+      </RecoilRoot>
+    </>
   );
 }
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,5 +1,7 @@
 import Document, { Html, Head, Main, NextScript } from 'next/document';
 
+import GTagScript from '@/components/GTagScript';
+
 class MyDocument extends Document {
   render() {
     return (
@@ -17,6 +19,7 @@ class MyDocument extends Document {
         <body>
           <Main />
           <NextScript />
+          <GTagScript />
         </body>
       </Html>
     );

--- a/src/pages/beer/recommend-and-liked.tsx
+++ b/src/pages/beer/recommend-and-liked.tsx
@@ -1,7 +1,51 @@
-import BeerRecommendAndLikedContainer from '@/containers/BeerRecommendAndLikedContainer';
+import { isNil } from 'lodash';
+import { useRouter } from 'next/router';
+import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
+import BeerRecommendAndLikedContainer from '@/containers/BeerRecommendAndLikedContainer';
+import { useGtagPageView } from '@/hooks';
+import QueryParams from '@/utils/query-params';
+
+/**
+ * tab="recommend" : 추천 맥주 목록
+ * tab="liked" : 반한 맥주 목록
+ */
 const BeerRecommendAndLikedPage = () => {
-  return <BeerRecommendAndLikedContainer />;
+  const [activatedIndex, setActivatedIndex] = useActivatedIndex();
+
+  useGtagPageView(activatedIndex === 1 ? '반한 맥주 목록' : '추천 맥주 목록');
+
+  return (
+    <BeerRecommendAndLikedContainer
+      activatedIndex={activatedIndex}
+      setActivatedIndex={setActivatedIndex}
+    />
+  );
 };
 
 export default BeerRecommendAndLikedPage;
+
+type TabType = 'recommend' | 'liked';
+
+const tabToIndex = (tab: TabType): number => {
+  return tab === 'liked' ? 1 : 0;
+};
+
+const indexToTab = (index: number): TabType => {
+  return index === 1 ? 'liked' : 'recommend';
+};
+
+const useActivatedIndex = (): [number, Dispatch<SetStateAction<number>>] => {
+  const {
+    query: { tab },
+  } = useRouter();
+  const parsedTab = !isNil(tab) ? JSON.parse(tab.toString()) : undefined;
+
+  const [activatedIndex, setActivatedIndex] = useState(tabToIndex(parsedTab));
+
+  useEffect(() => {
+    QueryParams.set('tab', indexToTab(activatedIndex));
+  }, [activatedIndex]);
+
+  return [activatedIndex, setActivatedIndex];
+};

--- a/src/pages/beer/recommend-and-liked.tsx
+++ b/src/pages/beer/recommend-and-liked.tsx
@@ -5,6 +5,7 @@ import { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import BeerRecommendAndLikedContainer from '@/containers/BeerRecommendAndLikedContainer';
 import { useGtagPageView } from '@/hooks';
 import QueryParams from '@/utils/query-params';
+import { PAGE_TITLES } from '@/constants';
 
 /**
  * tab="recommend" : 추천 맥주 목록
@@ -13,7 +14,7 @@ import QueryParams from '@/utils/query-params';
 const BeerRecommendAndLikedPage = () => {
   const [activatedIndex, setActivatedIndex] = useActivatedIndex();
 
-  useGtagPageView(activatedIndex === 1 ? '반한 맥주 목록' : '추천 맥주 목록');
+  useGtagPageView(activatedIndex === 1 ? PAGE_TITLES.LIKED : PAGE_TITLES.BEER_RECOMMEND);
 
   return (
     <BeerRecommendAndLikedContainer

--- a/src/pages/beer/request/complete.tsx
+++ b/src/pages/beer/request/complete.tsx
@@ -1,8 +1,9 @@
+import { PAGE_TITLES } from '@/constants';
 import BeerRequestCompleteContainer from '@/containers/BeerRequestCompleteContainer';
 import { useGtagPageView } from '@/hooks';
 
 const BeerRequestCompletePage = () => {
-  useGtagPageView('맥주요청 완료');
+  useGtagPageView(PAGE_TITLES.BEER_REQUEST_COMPLETE);
 
   return <BeerRequestCompleteContainer />;
 };

--- a/src/pages/beer/request/complete.tsx
+++ b/src/pages/beer/request/complete.tsx
@@ -1,6 +1,9 @@
 import BeerRequestCompleteContainer from '@/containers/BeerRequestCompleteContainer';
+import { useGtagPageView } from '@/hooks';
 
 const BeerRequestCompletePage = () => {
+  useGtagPageView('맥주요청 완료');
+
   return <BeerRequestCompleteContainer />;
 };
 

--- a/src/pages/beers/[id].tsx
+++ b/src/pages/beers/[id].tsx
@@ -2,9 +2,10 @@ import { NextPage } from 'next';
 
 import BeerDetailContainer from '@/containers/BeerDetailContainer';
 import { useGtagPageView } from '@/hooks';
+import { PAGE_TITLES } from '@/constants';
 
 const BeerDetailPage: NextPage = () => {
-  useGtagPageView('맥주 상세정보');
+  useGtagPageView(PAGE_TITLES.BEER_DETAIL);
 
   return <BeerDetailContainer />;
 };

--- a/src/pages/beers/[id].tsx
+++ b/src/pages/beers/[id].tsx
@@ -1,8 +1,11 @@
 import { NextPage } from 'next';
 
 import BeerDetailContainer from '@/containers/BeerDetailContainer';
+import { useGtagPageView } from '@/hooks';
 
 const BeerDetailPage: NextPage = () => {
+  useGtagPageView('맥주 상세정보');
+
   return <BeerDetailContainer />;
 };
 

--- a/src/pages/beers/index.tsx
+++ b/src/pages/beers/index.tsx
@@ -1,8 +1,11 @@
 import { NextPage } from 'next';
 
 import BeerListContainer from '@/containers/BeerListContainer';
+import { useGtagPageView } from '@/hooks';
 
 const BeerListPage: NextPage = () => {
+  useGtagPageView('맥주 목록');
+
   return <BeerListContainer />;
 };
 

--- a/src/pages/beers/index.tsx
+++ b/src/pages/beers/index.tsx
@@ -2,9 +2,10 @@ import { NextPage } from 'next';
 
 import BeerListContainer from '@/containers/BeerListContainer';
 import { useGtagPageView } from '@/hooks';
+import { PAGE_TITLES } from '@/constants';
 
 const BeerListPage: NextPage = () => {
-  useGtagPageView('맥주 목록');
+  useGtagPageView(PAGE_TITLES.BEER_LIST);
 
   return <BeerListContainer />;
 };

--- a/src/pages/etc.tsx
+++ b/src/pages/etc.tsx
@@ -1,8 +1,11 @@
 import { NextPage } from 'next';
 
 import EtcContainer from '@/containers/EtcContainer';
+import { useGtagPageView } from '@/hooks';
 
 const EtcPage: NextPage = () => {
+  useGtagPageView('프로필-기타');
+
   return <EtcContainer />;
 };
 

--- a/src/pages/etc.tsx
+++ b/src/pages/etc.tsx
@@ -2,9 +2,10 @@ import { NextPage } from 'next';
 
 import EtcContainer from '@/containers/EtcContainer';
 import { useGtagPageView } from '@/hooks';
+import { PAGE_TITLES } from '@/constants';
 
 const EtcPage: NextPage = () => {
-  useGtagPageView('프로필-기타');
+  useGtagPageView(PAGE_TITLES.ETC);
 
   return <EtcContainer />;
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,10 @@
 import type { NextPage } from 'next';
 
 import { useGtagPageView } from '@/hooks';
+import { PAGE_TITLES } from '@/constants';
 
 const Home: NextPage = () => {
-  useGtagPageView('홈');
+  useGtagPageView(PAGE_TITLES.HOME);
 
   return <div>sulsul</div>;
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,15 +1,11 @@
 import type { NextPage } from 'next';
-import Head from 'next/head';
+
+import { useGtagPageView } from '@/hooks';
 
 const Home: NextPage = () => {
-  return (
-    <div>
-      <Head>
-        <title>sulsul</title>
-      </Head>
-      sulsul
-    </div>
-  );
+  useGtagPageView('홈');
+
+  return <div>sulsul</div>;
 };
 
 export default Home;

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -2,9 +2,10 @@ import { useRouter } from 'next/router';
 
 import LoginContainer from '@/containers/LoginContainer';
 import { useGtagPageView } from '@/hooks';
+import { PAGE_TITLES } from '@/constants';
 
 const LoginPage = () => {
-  useGtagPageView('로그인');
+  useGtagPageView(PAGE_TITLES.LOGIN);
 
   const router = useRouter();
   const {

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,8 +1,11 @@
 import { useRouter } from 'next/router';
 
 import LoginContainer from '@/containers/LoginContainer';
+import { useGtagPageView } from '@/hooks';
 
 const LoginPage = () => {
+  useGtagPageView('로그인');
+
   const router = useRouter();
   const {
     query: { step = 1 },

--- a/src/pages/onboarding.tsx
+++ b/src/pages/onboarding.tsx
@@ -2,9 +2,10 @@ import { NextPage } from 'next';
 
 import OnBoardingContainer from '@/containers/OnBoardingContainer';
 import { useGtagPageView } from '@/hooks';
+import { PAGE_TITLES } from '@/constants';
 
 const OnBoardingPage: NextPage = () => {
-  useGtagPageView('시작하기');
+  useGtagPageView(PAGE_TITLES.ON_BOARDING);
 
   return <OnBoardingContainer />;
 };

--- a/src/pages/onboarding.tsx
+++ b/src/pages/onboarding.tsx
@@ -1,8 +1,11 @@
 import { NextPage } from 'next';
 
 import OnBoardingContainer from '@/containers/OnBoardingContainer';
+import { useGtagPageView } from '@/hooks';
 
 const OnBoardingPage: NextPage = () => {
+  useGtagPageView('시작하기');
+
   return <OnBoardingContainer />;
 };
 

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -1,8 +1,11 @@
 import { NextPage } from 'next';
 
 import PrivacyPolicyContainer from '@/containers/PrivacyPolicyContainer';
+import { useGtagPageView } from '@/hooks';
 
 const PrivacyPolicyPage: NextPage = () => {
+  useGtagPageView('개인정보 처리방침');
+
   return <PrivacyPolicyContainer />;
 };
 

--- a/src/pages/privacy-policy.tsx
+++ b/src/pages/privacy-policy.tsx
@@ -2,9 +2,10 @@ import { NextPage } from 'next';
 
 import PrivacyPolicyContainer from '@/containers/PrivacyPolicyContainer';
 import { useGtagPageView } from '@/hooks';
+import { PAGE_TITLES } from '@/constants';
 
 const PrivacyPolicyPage: NextPage = () => {
-  useGtagPageView('개인정보 처리방침');
+  useGtagPageView(PAGE_TITLES.PRIVACY_POLICY);
 
   return <PrivacyPolicyContainer />;
 };

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,6 +1,7 @@
 import { NextPage } from 'next';
 
 import ProfileContainer from '@/containers/ProfileContainer';
+import { useGtagPageView } from '@/hooks';
 
 const dummy = [
   {
@@ -14,6 +15,8 @@ const dummy = [
   },
 ];
 const ProfilePage: NextPage = () => {
+  useGtagPageView('프로필');
+
   const {
     nickname,
     email,
@@ -23,7 +26,7 @@ const ProfilePage: NextPage = () => {
     likedBeerCount,
     requestBeerCount,
   } = dummy[0];
-  
+
   return (
     <ProfileContainer
       nickname={nickname}

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -2,6 +2,7 @@ import { NextPage } from 'next';
 
 import ProfileContainer from '@/containers/ProfileContainer';
 import { useGtagPageView } from '@/hooks';
+import { PAGE_TITLES } from '@/constants';
 
 const dummy = [
   {
@@ -15,7 +16,7 @@ const dummy = [
   },
 ];
 const ProfilePage: NextPage = () => {
-  useGtagPageView('프로필');
+  useGtagPageView(PAGE_TITLES.PROFILE);
 
   const {
     nickname,

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -2,9 +2,10 @@ import { NextPage } from 'next';
 
 import TeamContainer from '@/containers/TeamContainer';
 import { useGtagPageView } from '@/hooks';
+import { PAGE_TITLES } from '@/constants';
 
 const TeamPage: NextPage = () => {
-  useGtagPageView('팀원 소개');
+  useGtagPageView(PAGE_TITLES.TEAM);
 
   return <TeamContainer />;
 };

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -1,8 +1,11 @@
 import { NextPage } from 'next';
 
 import TeamContainer from '@/containers/TeamContainer';
+import { useGtagPageView } from '@/hooks';
 
 const TeamPage: NextPage = () => {
+  useGtagPageView('팀원 소개');
+
   return <TeamContainer />;
 };
 

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -1,8 +1,11 @@
 import { NextPage } from 'next';
 
 import TermsOfServiceContainer from '@/containers/TermsOfServiceContainer';
+import { useGtagPageView } from '@/hooks';
 
 const TermsOfServicePage: NextPage = () => {
+  useGtagPageView('이용약관');
+
   return <TermsOfServiceContainer />;
 };
 

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -2,9 +2,10 @@ import { NextPage } from 'next';
 
 import TermsOfServiceContainer from '@/containers/TermsOfServiceContainer';
 import { useGtagPageView } from '@/hooks';
+import { PAGE_TITLES } from '@/constants';
 
 const TermsOfServicePage: NextPage = () => {
-  useGtagPageView('이용약관');
+  useGtagPageView(PAGE_TITLES.TERMS_OF_SERVICE);
 
   return <TermsOfServiceContainer />;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2806,6 +2806,11 @@
   dependencies:
     "@types/tinycolor2" "*"
 
+"@types/gtag.js@^0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.10.tgz#ac90d9b79c00daac447725a4b78ec1c398796760"
+  integrity sha512-98Hy7woUb3jMAMXkZQwfIOYNyfxmI0+U4m0PpCGdnd/FHk0tDpQFCqgXdNkdEoXsKkcGya/2Gew1cAJjKJspVw==
+
 "@types/hast@^2.0.0":
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.4.tgz#8aa5ef92c117d20d974a82bdfb6a648b08c0bafc"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8063,6 +8063,11 @@ nested-error-stacks@^2.0.0, nested-error-stacks@^2.1.0:
   resolved "https://registry.yarnpkg.com/nested-error-stacks/-/nested-error-stacks-2.1.1.tgz#26c8a3cee6cc05fbcf1e333cd2fc3e003326c0b5"
   integrity sha512-9iN1ka/9zmX1ZvLV9ewJYEk9h7RyRRtqdK0woXcqohu8EWIerfPUjYJPg0ULy0UqP7cslmdGc8xKDJcojlKiaw==
 
+next-seo@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/next-seo/-/next-seo-5.4.0.tgz#37a7784b30b3f70cec3fa0d77f9dde5990822d24"
+  integrity sha512-R9DhajPwJnR/lsF2hZ8cN8uqr5CVITsRrCG1AF5+ufcaybKYOvnH8sH9MaH4/hpkps3PQ9H71S7J7SPYixAYzQ==
+
 next@12.1.2:
   version "12.1.2"
   resolved "https://registry.yarnpkg.com/next/-/next-12.1.2.tgz#c5376a8ae17d3e404a2b691c01f94c8943306f29"


### PR DESCRIPTION
## 📍 주요 변경사항
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

- ga 초기 설정
- useGtagPageView 훅 추가 : 페이지별 한번씩 호출하여 페이지 접근 횟수를 측정합니다 
-> 참고링크 : https://developers.google.com/analytics/devguides/collection/ga4/views?technology=websites
-> pageTitle을 넘겨 주지 않는 경우 페이지의 title을 page_title 로 설정합니다

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->

<img width="322" alt="image" src="https://user-images.githubusercontent.com/39763891/172901596-6d5d07e5-b38b-4a3e-8380-4c37878bc932.png">



## 💡 중점적으로 봐주었으면 하는 부분
<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

- 리랜더링으로 인해 useGtagPageView이 여러번 호출되는 경우가 발생할 수도 있을 것 같아요,,
- 페이지별 네이밍은 저희가 알아보기 쉬운 이름으로 임시로 정해놓았는데 배포 직전에 일괄 수정해도 될 것같아요
- 버튼 클릭 등의 이벤트 측정도 완성하고,, 붙이면 될 것 같습니다!