### PR TITLE
feat: max font-size 설정

### DIFF
--- a/src/themes/GlobalStyle.tsx
+++ b/src/themes/GlobalStyle.tsx
@@ -87,6 +87,12 @@ const global = (theme: Readonly<ColorTheme & FontTheme>) => css`
     font-size: 2.6667vw;
   }
 
+  @media (min-width: 768px) {
+    html {
+      font-size: 20.477px;
+    }
+  }
+
   body {
     // https://github.com/orioncactus/pretendard
     font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue',


### PR DESCRIPTION
## 📍 주요 변경사항
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->
global 폰트 사이즈가 vw 기준이기 때문에 rem 단위로 작업한 ui는 화면너비가 768px이상인 경우 무턱대고 커지는 문제가 있었어요
그래서 768px 이상인 경우는 `font-size: 20.477px;`로 고정하여 화면너비가 커져도 UI에 영향이 없도록 수정했습니다

```css
@media (min-width: 768px) {
    html {
      font-size: 20.477px;
    }
  }
```


## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->


## 💡 중점적으로 봐주었으면 하는 부분
<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

max font-size 적용전
![image](https://user-images.githubusercontent.com/39763891/173175406-65e70259-b8b3-4154-bf51-b00c807af2a6.png)

max font-size 적용후
![image](https://user-images.githubusercontent.com/39763891/173175416-00667991-ea84-41c1-a772-bf2fe4866f3d.png)
