### PR TITLE
fix: :lipstick: 맥주 아이템 이미지 css 수정

### DIFF
--- a/src/components/beerItem/BeerGridItem/BeerGridItem.tsx
+++ b/src/components/beerItem/BeerGridItem/BeerGridItem.tsx
@@ -94,7 +94,8 @@ const BookmarkButton = styled.button`
 const BeerImage = styled.img`
   width: 100%;
   height: auto;
-  object-fit: cover;
+  max-height: 100%;
+  object-fit: contain;
 `;
 
 const StyledEmoji = styled.div`

--- a/src/components/beerItem/BeerListItem/BeerListItem.tsx
+++ b/src/components/beerItem/BeerListItem/BeerListItem.tsx
@@ -103,7 +103,8 @@ const StyledBeerImageMasking = styled(BeerImageMasking)`
 const BeerImage = styled.img`
   width: 100%;
   height: auto;
-  object-fit: cover;
+  max-height: 100%;
+  object-fit: contain;
 `;
 
 const TextContainer = styled.div`


### PR DESCRIPTION
## 📍 주요 변경사항
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

수정전
![image](https://user-images.githubusercontent.com/39763891/173180553-0b7e39af-60c6-4a2e-9296-951b99dbdc57.png)

수정후
![image](https://user-images.githubusercontent.com/39763891/173180589-41b64da4-6634-4cf8-82c1-f9368c2ce2cc.png)


요런 ui가 생기길래..ㅠㅠ 맥주 아이템 css를 수정했습니다 
max-height 100%, object-fit: cover -> contain으로 수정했어요!

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->


## 💡 중점적으로 봐주었으면 하는 부분
<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
