### PR TITLE
feat: :sparkles: usetAgent를 이용하여 mobile 과 web을 구분하는 util 구현

### DIFF
--- a/src/containers/RecordTicketContainer/CreateImage.tsx
+++ b/src/containers/RecordTicketContainer/CreateImage.tsx
@@ -6,6 +6,7 @@ import BeerTicket from '@/components/BeerTicket';
 import Button from '@/components/commons/Button';
 import { IRecord } from '@/apis/record';
 import { BEER_TICKET_WIDTH } from '@/components/BeerTicket/BeerTicket';
+import { getOSByUserAgent } from '@/utils/getUserAgentByOS';
 
 const CONTAINER_ID = 'beerair-ticket-image';
 
@@ -18,7 +19,8 @@ export interface CreateImageRef {
   create: () => Promise<boolean>;
   download: () => boolean;
 }
-function CreateImage({ record, className }: Props, ref: Ref<CreateImageRef>) {
+const CreateImage = ({ record, className }: Props, ref: Ref<CreateImageRef>) => {
+  const os = getOSByUserAgent();
   const containerRef = useRef<null | HTMLDivElement>(null);
   const canvasRef = useRef<null | HTMLCanvasElement>(null);
   const [imageSrc, setImageSrc] = useState<string | null>(null);
@@ -87,12 +89,13 @@ function CreateImage({ record, className }: Props, ref: Ref<CreateImageRef>) {
       {imageSrc && isCreateContainerOpen && (
         <CreatedContainer className={className} onClick={() => setIsCreateContainerOpen(false)}>
           <img src={imageSrc} alt="created-beer-ticket-image" />
-          <Button onClick={download}>이미지를 꾹 눌러 저장해보세요</Button>
+          {os === 'ios' && <Button onClick={download}>이미지를 꾹 눌러 저장해보세요</Button>}
+          {(os === 'android' || os === 'web') && <Button onClick={download}>다운로드</Button>}
         </CreatedContainer>
       )}
     </>
   );
-}
+};
 export default forwardRef(CreateImage);
 
 const CreatedContainer = styled.div`

--- a/src/utils/getUserAgentByOS.ts
+++ b/src/utils/getUserAgentByOS.ts
@@ -1,0 +1,21 @@
+import { isServer } from './isServer';
+
+export function getOSByUserAgent() {
+  if (isServer()) {
+    return 'web';
+  }
+
+  const isIos = window.navigator.userAgent.match(/ipad|iphone/i) !== null;
+
+  if (isIos) {
+    return 'ios';
+  }
+
+  const isAndroid = window.navigator.userAgent.match(/Android/i) !== null;
+
+  if (isAndroid) {
+    return 'android';
+  }
+
+  return 'web';
+}

--- a/src/utils/isServer.ts
+++ b/src/utils/isServer.ts
@@ -1,0 +1,5 @@
+export const isServer = (): boolean => {
+  return typeof window === 'undefined';
+};
+
+export default isServer;


### PR DESCRIPTION
## 📍 주요 변경사항
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->
- 티켓 이미지 저장 기능에서 생성된 이미지를 저장하는 버튼을 노출시킬 때 ios, android, web에 따라 텍스트를 달리 해야할 필요가 있어 util함수를 구현했습니다
- ios는 `이미지를 꾹 눌러 저장` android와 web은 다운로드 버튼 클릭시 바로 저장 가능

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->


## 💡 중점적으로 봐주었으면 하는 부분
<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
