### PR TITLE
feat: ✨유저 로그인 판별 기능 구현

### DIFF
--- a/src/apis/user/get-user.ts
+++ b/src/apis/user/get-user.ts
@@ -9,6 +9,11 @@ interface IGetUserResponse extends IBaseResponse<IUser> {}
  * 국가 목록 조회
  */
 export const getUser = async () => {
-  const res = await axios.get<IGetUserResponse>('/api/v1/members');
-  return res.data.contents;
+  try {
+    const res = await axios.get<IGetUserResponse>('/api/v1/members');
+    return res.data.contents;
+  } catch (error) {
+    console.error(error);
+    return undefined;
+  }
 };

--- a/src/components/LoginRequestModal/LoginRequestModal.tsx
+++ b/src/components/LoginRequestModal/LoginRequestModal.tsx
@@ -56,7 +56,7 @@ const LoginRequestModal: React.FC<LoginRequestModalProps> = ({ isOpen, onClose }
       <StyledLoginRequestModal>
         <div className="login-modal-content">
           <p className="login-modal-title">{'이용하려면 로그인이 필요합니다.'}</p>
-          <p className="login-modal-description">{'계정 등록 후 이용해주세요'}</p>
+          <p className="login-modal-description">{'계정 등록 후 이용해주세요.'}</p>
         </div>
         <Button type="primary" width="large" onClick={handleClick}>
           {'로그인 하러가기'}

--- a/src/components/LoginRequestModal/LoginRequestModal.tsx
+++ b/src/components/LoginRequestModal/LoginRequestModal.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { useRouter } from 'next/router';
+
+import Button from '@/components/commons/Button';
+import ModalLayout from '@/components/layouts/ModalLayout';
+
+interface LoginRequestModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const StyledLoginRequestModal = styled.section`
+  background-color: ${({ theme }) => theme.color.white};
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+  width: 300px;
+  height: 200px;
+  padding: 16px 16px 20px 16px;
+  border-radius: 12px;
+
+  & p.login-modal-title,
+  p.login-modal-description {
+    ${({ theme }) => theme.fonts.Body3};
+    color: ${({ theme }) => theme.color.grey4};
+
+    &.login-modal-title {
+      color: ${({ theme }) => theme.color.grey5};
+    }
+  }
+
+  & .login-modal-content {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 44px;
+  }
+`;
+
+const LoginRequestModal: React.FC<LoginRequestModalProps> = ({ isOpen, onClose }) => {
+  const router = useRouter();
+
+  const handleClick = () => {
+    router.replace('/login');
+  };
+
+  return (
+    <ModalLayout open={isOpen} onClose={onClose}>
+      <StyledLoginRequestModal>
+        <div className="login-modal-content">
+          <p className="login-modal-title">{'이용하려면 로그인이 필요합니다.'}</p>
+          <p className="login-modal-description">{'계정 등록 후 이용해주세요'}</p>
+        </div>
+        <Button type="primary" width="large" onClick={handleClick}>
+          {'로그인 하러가기'}
+        </Button>
+      </StyledLoginRequestModal>
+    </ModalLayout>
+  );
+};
+
+export default LoginRequestModal;

--- a/src/components/LoginRequestModal/index.ts
+++ b/src/components/LoginRequestModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './LoginRequestModal';

--- a/src/containers/HomeContainer/HomeContainer.stories.tsx
+++ b/src/containers/HomeContainer/HomeContainer.stories.tsx
@@ -1,12 +1,39 @@
 import { ComponentMeta, ComponentStory } from '@storybook/react';
+import { RecoilRoot } from 'recoil';
 
 import { Record } from '@/constants/Record';
+import { $userSession } from '@/recoil/atoms';
 
 import HomeContainer from './HomeContainer';
 
 export default {
   title: 'Pages/홈',
   component: HomeContainer,
+  decorators: [
+    (Story) => (
+      <RecoilRoot
+        initializeState={({ set }) => {
+          set($userSession, {
+            id: 1,
+            email: 'zizon@zizon.com',
+            name: '퇴근하고싶다',
+            phoneNumber: '010-0000-0000',
+            profileUrl: '',
+            role: 'test',
+            social: 'test',
+            memberLevelResponseDto: {
+              id: 1,
+              imageUrl: '',
+              req: 50,
+              tier: 4,
+            },
+          });
+        }}
+      >
+        <Story />
+      </RecoilRoot>
+    ),
+  ],
 } as ComponentMeta<typeof HomeContainer>;
 
 export const 홈: ComponentStory<typeof HomeContainer> = (args) => <HomeContainer {...args} />;
@@ -19,20 +46,5 @@ export const 홈: ComponentStory<typeof HomeContainer> = (args) => <HomeContaine
     nextCursor: 10,
     // contents: [{ ...Record }],
     contents: [{ ...Record }, { ...Record, id: 2 }, { ...Record, id: 3 }, { ...Record, id: 4 }],
-  },
-  user: {
-    id: 1,
-    email: 'zizon@zizon.com',
-    name: '퇴근하고싶다',
-    phoneNumber: '010-0000-0000',
-    profileUrl: '',
-    role: 'test',
-    social: 'test',
-    memberLevelResponseDto: {
-      id: 1,
-      imageUrl: '',
-      req: 50,
-      tier: 4,
-    },
   },
 };

--- a/src/containers/HomeContainer/HomeContainer.tsx
+++ b/src/containers/HomeContainer/HomeContainer.tsx
@@ -3,16 +3,18 @@ import React from 'react';
 import styled from '@emotion/styled';
 import Slider from 'react-slick';
 import Link from 'next/link';
+import { useRecoilValue } from 'recoil';
 
 import HomeSearchBar from './HomeSearchBar';
 
+import { $userSession } from '@/recoil/atoms';
 import { useGtagPageView } from '@/hooks';
-import { IGetMyRecordsResponseData, IUser, getMyRecords, getUser } from '@/apis';
+import { IGetMyRecordsResponseData, getMyRecords } from '@/apis';
 import Icon, { IconNameType } from '@/components/commons/Icon';
 import BottomNavigation from '@/components/BottomNavigation';
 import BottomFloatingButtonArea from '@/components/BottomFloatingButtonArea';
 import Button from '@/components/commons/Button';
-import { useGetMyRecords, useGetUser } from '@/queries';
+import { useGetMyRecords } from '@/queries';
 import HomeBeerTicket from '@/components/HomeBeerTicket';
 import { PAGE_TITLES } from '@/constants';
 
@@ -63,18 +65,15 @@ const StyledHomeContainer = styled.div`
 
 interface HomeContainerProps {
   myRecordResponse: IGetMyRecordsResponseData;
-  user: IUser;
 }
 
-const HomeContainer: NextPage<HomeContainerProps> = ({
-  user: _user,
-  myRecordResponse: _myRecordResponse,
-}) => {
-  useGtagPageView(PAGE_TITLES.HOME);
+const HomeContainer: NextPage<HomeContainerProps> = ({ myRecordResponse: _myRecordResponse }) => {
+  const user = useRecoilValue($userSession);
   const { data } = useGetMyRecords(_myRecordResponse);
-  const { contents: user } = useGetUser(_user);
 
   const [myRecords] = data?.pages || [];
+
+  useGtagPageView(PAGE_TITLES.HOME);
 
   return (
     <StyledHomeContainer>
@@ -133,9 +132,8 @@ const HomeContainer: NextPage<HomeContainerProps> = ({
 
 export const getServerSideProps: GetServerSideProps = async () => {
   const myRecordResponse = await getMyRecords();
-  const user = await getUser();
 
-  return { props: { myRecordResponse, user } };
+  return { props: { myRecordResponse } };
 };
 
 export default HomeContainer;

--- a/src/containers/HomeContainer/HomeContainer.tsx
+++ b/src/containers/HomeContainer/HomeContainer.tsx
@@ -135,7 +135,6 @@ const HomeContainer: NextPage<HomeContainerProps> = ({ myRecordResponse: _myReco
 export const getServerSideProps: GetServerSideProps = async (context) => {
   if (!hasAuthHeader(context)) {
     return { props: {} };
-    // return { props: {}, redirect: { destination: '/login', permanent: false } };
   }
   const myRecordResponse = await getMyRecords();
 

--- a/src/containers/HomeContainer/HomeContainer.tsx
+++ b/src/containers/HomeContainer/HomeContainer.tsx
@@ -7,6 +7,8 @@ import { useRecoilValue } from 'recoil';
 
 import HomeSearchBar from './HomeSearchBar';
 
+import hasAuth from '@/hocs/hasAuth';
+import { hasAuthHeader } from '@/utils/auth';
 import { $userSession } from '@/recoil/atoms';
 import { useGtagPageView } from '@/hooks';
 import { IGetMyRecordsResponseData, getMyRecords } from '@/apis';
@@ -130,10 +132,14 @@ const HomeContainer: NextPage<HomeContainerProps> = ({ myRecordResponse: _myReco
   );
 };
 
-export const getServerSideProps: GetServerSideProps = async () => {
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  if (!hasAuthHeader(context)) {
+    return { props: {} };
+    // return { props: {}, redirect: { destination: '/login', permanent: false } };
+  }
   const myRecordResponse = await getMyRecords();
 
   return { props: { myRecordResponse } };
 };
 
-export default HomeContainer;
+export default hasAuth(HomeContainer);

--- a/src/containers/HomeContainer/HomeContainer.tsx
+++ b/src/containers/HomeContainer/HomeContainer.tsx
@@ -141,4 +141,4 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   return { props: { myRecordResponse } };
 };
 
-export default hasAuth(HomeContainer);
+export default HomeContainer;

--- a/src/hocs/hasAuth.tsx
+++ b/src/hocs/hasAuth.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { useRecoilValue } from 'recoil';
+import { useRouter } from 'next/router';
+
+import { $userSession } from '@/recoil/atoms';
+
+const hasAuth =
+  <T extends any>(Component: React.FC<T>): React.FC<T> =>
+  // eslint-disable-next-line react/display-name
+  (props) => {
+    const router = useRouter();
+    const userSession = useRecoilValue($userSession);
+
+    if (!userSession) {
+      // TODO: 추후에 로그인 모달 추가
+      router.replace('/login');
+      return null;
+    }
+
+    return <Component {...props} />;
+  };
+
+export default hasAuth;

--- a/src/hocs/hasAuth.tsx
+++ b/src/hocs/hasAuth.tsx
@@ -1,20 +1,19 @@
 import React from 'react';
 import { useRecoilValue } from 'recoil';
-import { useRouter } from 'next/router';
 
 import { $userSession } from '@/recoil/atoms';
+import { useModal } from '@/hooks';
+import LoginRequestModal from '@/components/LoginRequestModal';
 
 const hasAuth =
   <T extends any>(Component: React.FC<T>): React.FC<T> =>
   // eslint-disable-next-line react/display-name
   (props) => {
-    const router = useRouter();
+    const { isOpen, close } = useModal(true);
     const userSession = useRecoilValue($userSession);
 
     if (!userSession) {
-      // TODO: 추후에 로그인 모달 추가
-      router.replace('/login');
-      return null;
+      return <LoginRequestModal isOpen={isOpen} onClose={close} />;
     }
 
     return <Component {...props} />;

--- a/src/hocs/hasAuth.tsx
+++ b/src/hocs/hasAuth.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { useRecoilValue } from 'recoil';
+import { NextPage } from 'next';
 
 import { $userSession } from '@/recoil/atoms';
 import { useModal } from '@/hooks';
 import LoginRequestModal from '@/components/LoginRequestModal';
 
 const hasAuth =
-  <T extends any>(Component: React.FC<T>): React.FC<T> =>
+  <T extends any>(Component: React.FC<T> | NextPage<T>): React.FC<T> =>
   // eslint-disable-next-line react/display-name
   (props) => {
     const { isOpen, close } = useModal(true);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -15,6 +15,7 @@ import mutedConsole from '@/utils/muteConsole';
 import { theme, GlobalStyle } from '@/themes';
 import queryClient from '@/configs/queryClient';
 import MainLayout from '@/components/layouts/MainLayout';
+import { setAuthHeader } from '@/utils/auth';
 
 awesome();
 initAxiosConfig();
@@ -73,6 +74,10 @@ MyApp.getInitialProps = async (appContext: AppContext) => {
 
     user = await getUser();
   }
+  if (!user) {
+    setAuthHeader(ctx);
+  }
+
   const appProps = await App.getInitialProps(appContext);
 
   return { ...appProps, userSession: user };

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,14 @@
 import { ThemeProvider } from '@emotion/react';
-import { RecoilRoot } from 'recoil';
+import { RecoilRoot, MutableSnapshot } from 'recoil';
 import App from 'next/app';
 import type { AppProps, AppContext } from 'next/app';
 import { QueryClientProvider } from 'react-query';
 import axios from 'axios';
 import { NextSeo } from 'next-seo';
+import { useMemo } from 'react';
 
+import { getUser, IUser } from '@/apis/user';
+import { $userSession } from '@/recoil/atoms';
 import { initAxiosConfig } from '@/configs/axios';
 import awesome from '@/utils/awesome';
 import mutedConsole from '@/utils/muteConsole';
@@ -19,7 +22,21 @@ initAxiosConfig();
 // ignore in-browser next/js recoil warnings until its fixed.
 global.console = mutedConsole(global.console);
 
-function MyApp({ Component, pageProps }: AppProps) {
+interface MyAppProps extends AppProps {
+  userSession?: IUser;
+}
+
+function MyApp({ Component, pageProps, userSession }: MyAppProps) {
+  const recoilInitializer = useMemo(
+    () =>
+      ({ set }: MutableSnapshot) => {
+        if (userSession) {
+          set($userSession, userSession);
+        }
+      },
+    [userSession],
+  );
+
   return (
     <>
       <NextSeo
@@ -31,7 +48,7 @@ function MyApp({ Component, pageProps }: AppProps) {
           images: [{ url: 'images/beerair_og.png', width: 1200, height: 600, alt: '비어에어' }],
         }}
       />
-      <RecoilRoot>
+      <RecoilRoot initializeState={recoilInitializer}>
         <QueryClientProvider client={queryClient}>
           <ThemeProvider theme={theme}>
             <GlobalStyle theme={theme} />
@@ -48,14 +65,17 @@ function MyApp({ Component, pageProps }: AppProps) {
 MyApp.getInitialProps = async (appContext: AppContext) => {
   const { ctx } = appContext;
   const cookie = ctx.req ? ctx.req.headers.cookie : null;
+  let user: IUser | undefined;
 
   axios.defaults.headers.common['Cookie'] = '';
   if (cookie) {
     axios.defaults.headers.common['Cookie'] = cookie;
+
+    user = await getUser();
   }
   const appProps = await App.getInitialProps(appContext);
 
-  return { ...appProps };
+  return { ...appProps, userSession: user };
 };
 
 export default MyApp;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,1 +1,6 @@
-export { default, getServerSideProps } from '@/containers/HomeContainer';
+import HomeContainer from '@/containers/HomeContainer';
+import hasAuth from '@/hocs/hasAuth';
+
+export { getServerSideProps } from '@/containers/HomeContainer';
+
+export default hasAuth(HomeContainer);

--- a/src/recoil/atoms/index.ts
+++ b/src/recoil/atoms/index.ts
@@ -1,2 +1,3 @@
 export * from './beerListViewType';
 export { default as $searchHistories } from './searchHistories';
+export { default as $userSession } from './userSession';

--- a/src/recoil/atoms/userSession.ts
+++ b/src/recoil/atoms/userSession.ts
@@ -1,0 +1,12 @@
+import { atom } from 'recoil';
+
+import { IUser } from '@/apis/user';
+
+const ATOM_KEY = 'user-session';
+
+const $userSession = atom<IUser | undefined>({
+  key: ATOM_KEY,
+  default: undefined,
+});
+
+export default $userSession;

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,13 @@
+import { NextPageContext, GetServerSidePropsContext } from 'next';
+
+const NON_AUTH_HEADER = 'not-logged-in';
+
+export const setAuthHeader = (ctx: NextPageContext) => {
+  if (ctx.req) {
+    ctx.req.headers[NON_AUTH_HEADER] = 'true';
+  }
+};
+
+export const hasAuthHeader = (ctx: NextPageContext | GetServerSidePropsContext) => {
+  return ctx.req?.headers[NON_AUTH_HEADER] !== 'true';
+};


### PR DESCRIPTION
## 📍 주요 변경사항
- user 데이터 조회하는 recoil 상태 구현 (초기 ssr에서도 상태 설정)
- 모든 페이지 접속 시 user데이터 조회 (해당 데이터로 guest/user api 분기 가능)
- 로그인 되지 않은 경우에는 hasAuth라는 hoc를 통해 로그인 모달이 나오게 되고 버튼을 클릭하면 로그인 페이지로 리다이렉트 됩니다

## 🔗 참고자료
<img width="421" alt="image" src="https://user-images.githubusercontent.com/49899406/174564838-a525abbe-db58-4efb-ab44-4ab21595dce5.png">


## 💡 중점적으로 봐주었으면 하는 부분
- App.getInitialProps -> Page.getServerSideProps 로 데이터를 넘겨주는 과정이 공식적으로는 제공되지 않는 것 같아 header에 user가 로그인되어있는지 필드를 하나 뚫어서 정의했습니다. - 비공식적인 방법은 있긴한데 공식문서에 나와있지 않은 내용으로 작업하면 추후 업데이트 시 side effect가 생길 수 있을것 같아 우선 이렇게 작업했어요
