### PR TITLE
style: :lipstick: search page에 placeholder 추가

### DIFF
--- a/src/containers/SearchContainer/SearchInput.tsx
+++ b/src/containers/SearchContainer/SearchInput.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/router';
 import { useSearchHistory } from '@/hooks';
 import Icon from '@/components/commons/Icon';
 
+const PLACEHOLDER_TEXT = '맥주 이름, 특징 검색';
 interface SearchInputProps {
   searchText: string;
   setSearchText: React.Dispatch<React.SetStateAction<string>>;
@@ -23,6 +24,10 @@ const StyledSearchInput = styled.div`
       color: ${({ theme }) => theme.color.white};
       padding: 20px 10px;
       width: 100%;
+
+      &::placeholder {
+        ${({ theme }) => theme.color.whiteOpacity35};
+      }
     }
   }
 `;
@@ -51,7 +56,13 @@ const SearchInput: React.FC<SearchInputProps> = ({ searchText, setSearchText }) 
   return (
     <StyledSearchInput onSubmit={handleSubmit}>
       <form onSubmit={handleSubmit}>
-        <input type="text" className="search-input" onChange={handleChange} value={searchText} />
+        <input
+          type="text"
+          className="search-input"
+          onChange={handleChange}
+          value={searchText}
+          placeholder={PLACEHOLDER_TEXT}
+        />
       </form>
       {searchText && (
         <button onClick={handleReset}>


### PR DESCRIPTION
## 📍 주요 변경사항
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->
search page에 placeholder 추가하는거 어떤가요?
너무 빈 페이지만 있으니 검색페이지인지 모르는 경우도 있을것 같아요!

### AS-IS
<img width="403" alt="image" src="https://user-images.githubusercontent.com/60775453/175820942-05f9616d-4d21-448c-beee-e8fc71e4825b.png">

### TO-BE
<img width="403" alt="image" src="https://user-images.githubusercontent.com/60775453/175820898-a4946033-5c3e-494e-82c5-35c9593a4eea.png">


## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->


## 💡 중점적으로 봐주었으면 하는 부분
<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
