### PR TITLE
fix: 🐛 createRecord 페이지 하단 버튼 반응형 대응

### DIFF
--- a/src/containers/UpsertRecordContainer/RecordSecondStepContainer/RecordSecondStepContainer.tsx
+++ b/src/containers/UpsertRecordContainer/RecordSecondStepContainer/RecordSecondStepContainer.tsx
@@ -45,6 +45,10 @@ const StyledRecordSecondStepContainer = styled.div`
     left: 100vw;
     justify-content: space-between;
     padding: 0 20px;
+
+    @media (min-width: 768px) {
+      left: 768px;
+    }
   }
 
   & .button-inner {

--- a/src/containers/UpsertRecordContainer/RecordThirdStepContainer/RecordThirdStepContainer.tsx
+++ b/src/containers/UpsertRecordContainer/RecordThirdStepContainer/RecordThirdStepContainer.tsx
@@ -84,6 +84,10 @@ const StyledBottomFloatingButtonArea = styled(BottomFloatingButtonArea)`
   left: 200vw;
   justify-content: space-between;
   padding: 0 20px;
+
+  @media (min-width: 768px) {
+    left: 1536px;
+  }
 `;
 
 const RecordThirdStepContainer: React.FC<RecordThirdStepContainerProps> = ({


### PR DESCRIPTION
## 📍 주요 변경사항
- createRecord 페이지 하단 버튼 반응형 대응

## 🔗 참고자료
- <img width="672" alt="image" src="https://user-images.githubusercontent.com/49899406/175974417-0b509b1a-fb0f-4733-845e-3f4fadf9ab63.png">

## 💡 중점적으로 봐주었으면 하는 부분
<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->
