### PR TITLE
fix: 🐛 refresh api memory leak 수정 및 client side 적용

### DIFF
--- a/src/apis/user/refresh-access-token.ts
+++ b/src/apis/user/refresh-access-token.ts
@@ -2,12 +2,18 @@ import axios from 'axios';
 
 import { IBaseResponse } from '..';
 
+interface IRefreshAccessTokenResponse
+  extends IBaseResponse<{
+    accessToken: string;
+    responseToken: string;
+  }> {}
+
 /**
  * refreshToken으로 accessToken 갱신
  */
 export const refreshAccessToken = async () => {
   try {
-    const res = await axios.get<IBaseResponse<object>>('/api/v1/token/refresh');
+    const res = await axios.get<IRefreshAccessTokenResponse>('/api/v1/token/refresh');
     return res.data;
   } catch (error) {
     console.error(error);

--- a/src/configs/axios.ts
+++ b/src/configs/axios.ts
@@ -13,24 +13,17 @@ export const initAxiosConfig = () => {
 };
 
 export const initAxiosRefreshConfig = () => {
-  axios.interceptors.response.use(
-    (response) => {
-      return response;
-    },
-    async (error) => {
-      const {
-        config,
-        response: { status },
-      } = error;
+  axios.interceptors.response.use(async (response) => {
+    const { config, data } = response;
 
-      if (status === 401) {
-        const originalRequest = config;
-        // refreshToken으로 accessToken 갱신
-        await refreshAccessToken();
-        // 401로 요청 실패했던 요청 새로운 토큰으로 재요청
-        return axios(originalRequest);
-      }
-      return Promise.reject(error);
-    },
-  );
+    if (data?.error?.code === 401) {
+      const originalRequest = config;
+      // refreshToken으로 accessToken 갱신
+      await refreshAccessToken();
+      // 401로 요청 실패했던 요청 새로운 토큰으로 재요청
+      return axios(originalRequest);
+    }
+
+    return response;
+  });
 };

--- a/src/configs/axios.ts
+++ b/src/configs/axios.ts
@@ -1,5 +1,7 @@
 import axios from 'axios';
 
+import { refreshAccessToken } from '@/apis/user';
+
 const isServer = typeof window === 'undefined';
 
 export const BASE_URL: string = process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
@@ -8,4 +10,27 @@ export const initAxiosConfig = () => {
   axios.defaults.baseURL = process.env.NODE_ENV === 'production' || isServer ? BASE_URL ?? '' : '';
   axios.defaults.timeout = 3000;
   axios.defaults.withCredentials = true;
+};
+
+export const initAxiosRefreshConfig = () => {
+  axios.interceptors.response.use(
+    (response) => {
+      return response;
+    },
+    async (error) => {
+      const {
+        config,
+        response: { status },
+      } = error;
+
+      if (status === 401) {
+        const originalRequest = config;
+        // refreshToken으로 accessToken 갱신
+        await refreshAccessToken();
+        // 401로 요청 실패했던 요청 새로운 토큰으로 재요청
+        return axios(originalRequest);
+      }
+      return Promise.reject(error);
+    },
+  );
 };


### PR DESCRIPTION
## 📍 주요 변경사항
- 기존 axios intercepter가 getInitialProps에 적용되어 있어 server side에서 동작
  - client side에서도 동작하도록 코드 수정
  - getInitialProps는 사용자 요청시마다 호출되기 때문에 axios intercepter가 무한 증식되는 현상 발생
  - 초기 1회 getUser api 호출 시 실패하면 refresh api를 호출하고 이전 요청 재요청하도록 설정
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

## 🔗 참고자료

## 💡 중점적으로 봐주었으면 하는 부분
