### PR TITLE
fix: 🐛 맥주 목록 버벅이는 문제, 맥주 목록 뒤로가기 버튼 제거

### DIFF
--- a/src/components/BeerListPageHeader/BeerListPageHeader.tsx
+++ b/src/components/BeerListPageHeader/BeerListPageHeader.tsx
@@ -66,7 +66,7 @@ const SearchBox = () => {
 
 const BeerListPageHeader = () => {
   return (
-    <Header leftExtras={<BackButton />} rightExtras={<BeerListViewToggleButton />}>
+    <Header rightExtras={<BeerListViewToggleButton />}>
       <SearchBox />
     </Header>
   );

--- a/src/containers/BeerListContainer/BeerListContainer.tsx
+++ b/src/containers/BeerListContainer/BeerListContainer.tsx
@@ -11,6 +11,7 @@ import {
   $beerListSortBy,
   BEER_LIST_FILTER_ATOM_KEY,
   BEER_LIST_SORT_BY_ATOM_KEY,
+  DEFAULT_BEER_LIST_SORT_BY,
 } from './recoil/atoms';
 
 import BeerListPageHeader from '@/components/BeerListPageHeader';
@@ -18,7 +19,7 @@ import BeerListFilterAndSorter from '@/components/BeerListFilterAndSorter';
 import BeerListSearchResult from '@/components/BeerSearchResultList';
 import BottomNavigation from '@/components/BottomNavigation';
 import { useGetBeersCount, useGetBeers } from '@/queries';
-import { getBeers, IGetBeersResponseData } from '@/apis';
+import { EBeerSortBy, getBeers, IGetBeersResponseData } from '@/apis';
 import { useGtagPageView } from '@/hooks';
 import { PAGE_TITLES } from '@/constants';
 import LoadingIcon from '@/components/LoadingIcon';
@@ -70,17 +71,23 @@ const BeerListContainer: NextPage<BeerListContainerProps> = ({ beersData: initia
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   if (context.query) {
+    const query = isNil(context.query.query) ? undefined : decodeURI(String(context.query.query));
     const filter = context.query[BEER_LIST_FILTER_ATOM_KEY]
       ? JSON.parse(context.query[BEER_LIST_FILTER_ATOM_KEY] as string)
       : undefined;
     const sortBy = context.query[BEER_LIST_SORT_BY_ATOM_KEY]
-      ? [(context.query[BEER_LIST_SORT_BY_ATOM_KEY] as string).replace(/["]/g, '')]
+      ? [(context.query[BEER_LIST_SORT_BY_ATOM_KEY] as string).replace(/["]/g, '') as EBeerSortBy]
       : undefined;
+
+    const payload = {
+      ...(query ? { query } : {}),
+      ...(filter ? { filter } : {}),
+      sortBy: sortBy || [DEFAULT_BEER_LIST_SORT_BY],
+    };
 
     const beersData = await getBeers({
       payload: {
-        ...(filter ? filter : {}),
-        ...(sortBy ? sortBy : {}),
+        ...payload,
         limit: 21,
       },
       /** @todo auth */

--- a/src/containers/BeerListContainer/BeerListContainer.tsx
+++ b/src/containers/BeerListContainer/BeerListContainer.tsx
@@ -25,7 +25,7 @@ import { PAGE_TITLES } from '@/constants';
 import LoadingIcon from '@/components/LoadingIcon';
 
 interface BeerListContainerProps {
-  beersData: IGetBeersResponseData;
+  beersData?: IGetBeersResponseData;
 }
 
 const BeerListContainer: NextPage<BeerListContainerProps> = ({ beersData: initialBeersData }) => {
@@ -70,32 +70,37 @@ const BeerListContainer: NextPage<BeerListContainerProps> = ({ beersData: initia
 };
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
-  if (context.query) {
-    const query = isNil(context.query.query) ? undefined : decodeURI(String(context.query.query));
-    const filter = context.query[BEER_LIST_FILTER_ATOM_KEY]
-      ? JSON.parse(context.query[BEER_LIST_FILTER_ATOM_KEY] as string)
-      : undefined;
-    const sortBy = context.query[BEER_LIST_SORT_BY_ATOM_KEY]
-      ? [(context.query[BEER_LIST_SORT_BY_ATOM_KEY] as string).replace(/["]/g, '') as EBeerSortBy]
-      : undefined;
+  try {
+    if (context.query) {
+      const query = isNil(context.query.query) ? undefined : decodeURI(String(context.query.query));
+      const filter = context.query[BEER_LIST_FILTER_ATOM_KEY]
+        ? JSON.parse(context.query[BEER_LIST_FILTER_ATOM_KEY] as string)
+        : undefined;
+      const sortBy = context.query[BEER_LIST_SORT_BY_ATOM_KEY]
+        ? [(context.query[BEER_LIST_SORT_BY_ATOM_KEY] as string).replace(/["]/g, '') as EBeerSortBy]
+        : undefined;
 
-    const payload = {
-      ...(query ? { query } : {}),
-      ...(filter ? { filter } : {}),
-      sortBy: sortBy || [DEFAULT_BEER_LIST_SORT_BY],
-    };
+      const payload = {
+        ...(query ? { query } : {}),
+        ...(filter ? { filter } : {}),
+        sortBy: sortBy || [DEFAULT_BEER_LIST_SORT_BY],
+      };
 
-    const beersData = await getBeers({
-      payload: {
-        ...payload,
-        limit: 21,
-      },
-      /** @todo auth */
-      auth: false,
-    });
+      const beersData = await getBeers({
+        payload: {
+          ...payload,
+          limit: 21,
+        },
+        /** @todo auth */
+        auth: false,
+      });
 
-    return { props: { beersData } };
+      return { props: { beersData } };
+    }
+  } catch {
+    return { props: {} };
   }
+
   return { props: {} };
 };
 

--- a/src/containers/BeerListContainer/recoil/atoms/beerListSortBy.ts
+++ b/src/containers/BeerListContainer/recoil/atoms/beerListSortBy.ts
@@ -18,8 +18,10 @@ export const beerListSortTypeTextAlias: Record<BeerListSortType, string> = {
   [EBeerSortBy.ALCOHOL_ASC]: '낮은 도수 순',
 };
 
+export const DEFAULT_BEER_LIST_SORT_BY = EBeerSortBy.RECORD_DESC;
+
 export const $beerListSortBy = atom<BeerListSortType>({
   key: BEER_LIST_SORT_BY_ATOM_KEY,
-  default: EBeerSortBy.RECORD_DESC,
+  default: DEFAULT_BEER_LIST_SORT_BY,
   effects: [urlSyncRecoilEffect(BEER_LIST_SORT_BY_ATOM_KEY)],
 });

--- a/src/queries/useGetBeers.ts
+++ b/src/queries/useGetBeers.ts
@@ -12,9 +12,15 @@ export const useGetBeers = (
 ) => {
   const userSession = useRecoilValue($userSession);
 
+  const payload = {
+    ...(query ? { query } : {}),
+    ...(filter ? { filter } : {}),
+    ...(sortBy ? { sortBy } : {}),
+  };
+
   const initialPageParam: { payload: IGetBeersPayload; auth: boolean } = {
     payload: {
-      ...{ query, filter, sortBy },
+      ...payload,
       cursor: 0,
       limit: DEFAULT_LIMIT,
     },
@@ -22,7 +28,7 @@ export const useGetBeers = (
   };
 
   return useInfiniteScrollList<IGetBeersResponseData, { payload: IGetBeersPayload; auth: boolean }>(
-    ['beers', { query, filter, sortBy }],
+    ['beers', payload],
     getBeers,
     {
       cacheTime: Infinity,


### PR DESCRIPTION
## 📍 주요 변경사항
<!-- 구현 내용 및 작업 했던 내역 -->
<!-- 작업 내용을 이미지나 gif로 첨부해도 좋습니다 -->

fix #211 
fix #207 

## 🔗 참고자료
<!-- 디자인 시안 링크 또는 레퍼런스 등 참고할만한 자료 -->


## 💡 중점적으로 봐주었으면 하는 부분
<!-- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점 -->

- getServerSideProps에서 오류가 나는 경우 아예 빈화면이 뜨는 것보다 아래처럼 목록만 없는게 나을 것 같아서 try catch 추가했습니다!

<img width="403" alt="image" src="https://user-images.githubusercontent.com/39763891/176837279-cd6177bc-c26b-4203-8ab4-11bdaf670db6.png">

처음에는 맥주 목록인 경우, 맥주 선택하는 페이지 (바텀 네비게이션 없애기) 인 경우 분리해서 뒤로가기 버튼을 있고, 없게 만들려고 했는데
아예 목적이 달라서 추후 다른페이지로 분리하는 것이 더 맞을 것 같다는 생각이들었어요
(맥주 목록 === + 버튼 클릭시 페이지가 같은 것 -> 사용자 입장에서 헷갈릴것같아서 디자인과 협의해서 추후 수정하는 것이 좋아보입니다ㅠ)

우선 뒤로가기 버튼만 없앴습니다!

